### PR TITLE
Issue 22 rewrite code for race analyses thus race highlights are identified w/o recording the whole race

### DIFF
--- a/Phases/AnalyseRace.cs
+++ b/Phases/AnalyseRace.cs
@@ -112,7 +112,15 @@ namespace iRacingReplayOverlay.Phases
             
             //Start iRacing Replay from the beginning with maximum speed (16x)
             iRacing.Replay.MoveToFrame(raceStartFrameNumber);
-            iRacing.Replay.SetSpeed((int)curReplaySpeed);
+            
+
+
+            //if (shortTestOnly)
+            //{
+            //    samples = samples.AtSpeed(Settings.Default.TimingFactorForShortTest);
+            //    Settings.AppliedTimingFactor = 1.0 / Settings.Default.TimingFactorForShortTest;
+            //}
+
 
             //copied from iRacing.Capturing because race events in app V1.0.x.x are identified during capturing the whole video. 
             //var overlayData = new OverlayData();
@@ -142,8 +150,13 @@ namespace iRacingReplayOverlay.Phases
                 .WithPitStopCounts()
                 .TakeUntil(3.Seconds()).Of(d => d.Telemetry.LeaderHasFinished && d.Telemetry.RaceCars.All(c => c.HasSeenCheckeredFlag || c.HasRetired || c.TrackSurface != TrackLocation.OnTrack))
                 .TakeUntil(3.Seconds()).AfterReplayPaused();
-            samples = samples.AtSpeed((int)curReplaySpeed);
-            Settings.AppliedTimingFactor = 1.0 / (int)curReplaySpeed;
+
+
+            //set speed for analysis phase (target speed is FF16x)
+            samples = samples.AtSpeed(Settings.Default.TimingFactorForShortTest);
+            Settings.AppliedTimingFactor = 1.0 / Settings.Default.TimingFactorForShortTest;
+
+            iRacing.Replay.SetSpeed((int)curReplaySpeed);
 
             var startTime = DateTime.Now;
 

--- a/Phases/AnalyseRace.cs
+++ b/Phases/AnalyseRace.cs
@@ -157,7 +157,7 @@ namespace iRacingReplayOverlay.Phases
             samples = samples.AtSpeed(Settings.Default.TimingFactorForShortTest);
             Settings.AppliedTimingFactor = 1.0 / Settings.Default.TimingFactorForShortTest;
 
-            iRacing.Replay.SetSpeed((int)curReplaySpeed);
+            //iRacing.Replay.SetSpeed((int)curReplaySpeed);
 
             var startTime = DateTime.Now;
 
@@ -165,8 +165,12 @@ namespace iRacingReplayOverlay.Phases
 
             foreach (var data in samples)
             {
-                var relativeTime = (DateTime.Now - startTime).Multiply(3.0);
-                
+                var relativeTime = (DateTime.Now - startTime).Multiply(Settings.Default.TimingFactorForShortTest);
+                var prevRelativeTime = DateTime.Now - startTime;
+
+                TraceDebug.WriteLine("Processing Data Sample at relative time: {0} |  {1}".F(relativeTime, prevRelativeTime));
+
+
                 replayControl.Process(data);
                 sessionDataCapture.Process(data);
                 captureLeaderBoardEveryHalfSecond.Process(data, relativeTime);

--- a/Phases/AnalyseRace.cs
+++ b/Phases/AnalyseRace.cs
@@ -23,6 +23,7 @@
 using iRacingReplayOverlay.Phases.Analysis;
 using iRacingReplayOverlay.Phases.Capturing;
 using iRacingReplayOverlay.Phases.Direction;
+using iRacingReplayOverlay.Support;
 using iRacingSDK;
 using iRacingSDK.Support;
 using System;
@@ -164,8 +165,8 @@ namespace iRacingReplayOverlay.Phases
 
             foreach (var data in samples)
             {
-                var relativeTime = DateTime.Now - startTime;
-
+                var relativeTime = (DateTime.Now - startTime).Multiply(3.0);
+                
                 replayControl.Process(data);
                 sessionDataCapture.Process(data);
                 captureLeaderBoardEveryHalfSecond.Process(data, relativeTime);

--- a/Phases/CaptureRace.cs
+++ b/Phases/CaptureRace.cs
@@ -64,8 +64,8 @@ namespace iRacingReplayOverlay.Phases
                 var totalRaceEvents = RaceEventExtension.GetInterestingRaceEvents(overlayData.RaceEvents.ToList());
 
                 //set iRacing Replay to Race start and ensure that iRacing is playing out replay at normal speed
-                iRacing.Replay.MoveToStartOfRace();                                     //move in iRacing replay to start of Race
-                iRacing.Replay.SetSpeed(1);                                             //set replay speed to normal
+                iRacing.Replay.MoveToFrame(raceStartFrameNumber);                       //move in iRacing replay to start of Race
+                iRacing.Replay.SetSpeed((int)replaySpeeds.normal);                      //set replay speed to normal
 
                 //Record the selected race events into a highlight video
                 var highligtVideoCapture = new VideoCapture();                          //create instance to control by sending hot-keys to recording software (tested with OBS)
@@ -81,7 +81,7 @@ namespace iRacingReplayOverlay.Phases
                     //jump to selected RaceEvent in iRacing Replay
                     int framePositionInRace = raceStartFrameNumber + (int)Math.Round(raceEvent.StartTime * 60.0);
                     iRacing.Replay.MoveToFrame(raceStartFrameNumber + (int)Math.Round(raceEvent.StartTime * 60.0));
-                    iRacing.Replay.SetSpeed((int)replaySpeeds.normal);
+                    
 
                     highligtVideoCapture.Resume();                                      //resume recording
                     

--- a/Phases/CaptureRace.cs
+++ b/Phases/CaptureRace.cs
@@ -81,6 +81,7 @@ namespace iRacingReplayOverlay.Phases
                     //jump to selected RaceEvent in iRacing Replay
                     int framePositionInRace = raceStartFrameNumber + (int)Math.Round(raceEvent.StartTime * 60.0);
                     iRacing.Replay.MoveToFrame(raceStartFrameNumber + (int)Math.Round(raceEvent.StartTime * 60.0));
+                    iRacing.Replay.SetSpeed((int)replaySpeeds.normal);
 
                     highligtVideoCapture.Resume();                                      //resume recording
                     

--- a/Phases/Direction/VideoCapture.cs
+++ b/Phases/Direction/VideoCapture.cs
@@ -115,7 +115,7 @@ namespace iRacingReplayOverlay.Phases.Direction
         //methode sending key-stroke command to resume recording software
         public void Resume()
         {
-            if (curVideoStatus == videoStatus.running && curVideoStatus == videoStatus.paused)
+            if (curVideoStatus == videoStatus.paused)
             {
                 SendKeyStroke_PauseResume();
                 curVideoStatus = videoStatus.running;

--- a/Support/Extensions.cs
+++ b/Support/Extensions.cs
@@ -66,4 +66,24 @@ namespace iRacingReplayOverlay.Support
             return -1;
         }
     }
+
+
+    public static class TimeSpanExtension
+    {
+        /// <summary>
+        /// Multiplies a timespan by an integer value
+        /// </summary>
+        public static TimeSpan Multiply(this TimeSpan multiplicand, int multiplier)
+        {
+            return TimeSpan.FromTicks(multiplicand.Ticks * multiplier);
+        }
+
+        /// <summary>
+        /// Multiplies a timespan by a double value
+        /// </summary>
+        public static TimeSpan Multiply(this TimeSpan multiplicand, double multiplier)
+        {
+            return TimeSpan.FromTicks((long)(multiplicand.Ticks * multiplier));
+        }
+    }
 }

--- a/iRacingReplayOverlay.net.Tests/iRacingReplayOverlay.net.Tests.csproj
+++ b/iRacingReplayOverlay.net.Tests/iRacingReplayOverlay.net.Tests.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <UseVSHostingProcess>true</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>


### PR DESCRIPTION
Fixes wrong determination of replay times relative to race start when analysis is being done at speed >1 (e.g. FF16x). 

Fixes issue #22 