### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://merlincooper.visualstudio.com/e6f13734-ec60-4c67-b13c-08641fd28b90/aba5fdb2-a95f-4c59-a57a-c7bc2140e80e/_apis/work/boardbadge/7e4ac0d3-9a8d-4dd6-a01a-49909ee3bae6)](https://merlincooper.visualstudio.com/e6f13734-ec60-4c67-b13c-08641fd28b90/_boards/board/t/aba5fdb2-a95f-4c59-a57a-c7bc2140e80e/Microsoft.RequirementCategory)
 iRacingReplayOverlay.net
 ========================
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#4](https://merlincooper.visualstudio.com/e6f13734-ec60-4c67-b13c-08641fd28b90/_workitems/edit/4). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.