### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/MerlinCooperDev/95d08889-0263-422c-90ee-87c9b773fec0/896622d3-fcb2-4b1b-bb89-94327190458f/_apis/work/boardbadge/f92ebc98-30a0-4135-8f1f-787fae8dc628)](https://dev.azure.com/MerlinCooperDev/95d08889-0263-422c-90ee-87c9b773fec0/_boards/board/t/896622d3-fcb2-4b1b-bb89-94327190458f/Microsoft.RequirementCategory)
 [![Build Status](https://dev.azure.com/MerlinCooperDev/iRacingReplayDirector/_apis/build/status/MerlinCooper.iRacingReplayDirector?branchName=master)](https://dev.azure.com/MerlinCooperDev/iRacingReplayDirector/_build/latest?definitionId=2&branchName=master)
  
 iRacingReplayDirector


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/MerlinCooperDev/95d08889-0263-422c-90ee-87c9b773fec0/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.