### PR TITLE
Enhanced incident selection when preferrred driver only is checked

### DIFF
--- a/Phases/Analysis/Incident.cs
+++ b/Phases/Analysis/Incident.cs
@@ -22,6 +22,7 @@ using iRacingSDK.Support;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using iRacingReplayDirector.Phases.Direction.Support;
 
 namespace iRacingReplayDirector.Phases.Analysis
 {
@@ -49,6 +50,8 @@ namespace iRacingReplayDirector.Phases.Analysis
 
         public void Process(DataSample data)
         {
+                       //
+
             if (data.Telemetry.CamCar.TrackSurface == TrackLocation.InPitStall ||
                 data.Telemetry.CamCar.TrackSurface == TrackLocation.NotInWorld ||
                 data.Telemetry.CamCar.TrackSurface == TrackLocation.AproachingPits)
@@ -56,7 +59,14 @@ namespace iRacingReplayDirector.Phases.Analysis
                 TraceInfo.WriteLine("{0} Ignoring incident in the pits on lap {1}", data.Telemetry.SessionTimeSpan, data.Telemetry.RaceLaps);
                 return;
             }
-
+            
+            //when FocusOnPrefered drivers is selected and current data not belongs to driver listed as prefered driver 
+            if (Settings.Default.FocusOnPreferedDriver && !Battle.GetPreferredCarIdxs(data, Settings.Default.PreferredDrivers).Contains(data.Telemetry.CamCar.Details.CarIdx))
+            {
+                TraceInfo.WriteLine("{0} Ignoring incident of car {1} because FocusOnPrefered driver active", data.Telemetry.SessionTimeSpan, data.Telemetry.CamCar.Details.Driver.UserName);
+                return;
+            }
+                        
             var i = new Incident 
             {
                 LapNumber = data.Telemetry.RaceLaps, 

--- a/Phases/Analysis/Incident.cs
+++ b/Phases/Analysis/Incident.cs
@@ -22,6 +22,7 @@ using iRacingSDK.Support;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using iRacingReplayDirector.Phases.Direction.Support;
 
 namespace iRacingReplayDirector.Phases.Analysis
 {
@@ -49,6 +50,8 @@ namespace iRacingReplayDirector.Phases.Analysis
 
         public void Process(DataSample data)
         {
+                       //
+
             if (data.Telemetry.CamCar.TrackSurface == TrackLocation.InPitStall ||
                 data.Telemetry.CamCar.TrackSurface == TrackLocation.NotInWorld ||
                 data.Telemetry.CamCar.TrackSurface == TrackLocation.AproachingPits)
@@ -56,7 +59,25 @@ namespace iRacingReplayDirector.Phases.Analysis
                 TraceInfo.WriteLine("{0} Ignoring incident in the pits on lap {1}", data.Telemetry.SessionTimeSpan, data.Telemetry.RaceLaps);
                 return;
             }
+            
+            //when FocusOnPrefered drivers is selected and current data not belongs to driver listed as prefered driver 
+            if (Settings.Default.FocusOnPreferedDriver && !Battle.GetPreferredCarIdxs(data, Settings.Default.PreferredDrivers).Contains(data.Telemetry.CamCar.Details.CarIdx))
+            {
+                TraceInfo.WriteLine("{0} Ignoring incident of car {1} because FocusOnPrefered driver active", data.Telemetry.SessionTimeSpan, data.Telemetry.CamCar.Details.Driver.UserName);
+                return;
+                /********* Clean-up *****************
 
+                //check whether incident belongs to driver in preferred drivers list. 
+
+                //bool isPreferred = Array.Exists(preferedCarIdxs, data.Telemetry.CamCar.Details.CarIdx);
+                long curCarLdx = data.Telemetry.CamCar.Details.CarIdx;
+                long[] preferedCarIdxs = Battle.GetPreferredCarIdxs(data, Settings.Default.PreferredDrivers);
+                //bool isPreferred = preferedCarIdxs.Contains(curCarLdx);
+
+                bool isPreferred = Battle.GetPreferredCarIdxs(data, Settings.Default.PreferredDrivers).Contains(curCarLdx);
+                ******** end clean-up **********/
+            }
+                        
             var i = new Incident 
             {
                 LapNumber = data.Telemetry.RaceLaps, 


### PR DESCRIPTION
Code added to ensure that only incidents of drivers listed in the preferred driver list get noted when "Focus on preferred" is selected in the configuration dialog.

addresses issue #28