### PR TITLE
Issue 65 abborts capture on phoenix dirt track rally cross

### DIFF
--- a/Main.Designer.cs
+++ b/Main.Designer.cs
@@ -53,8 +53,13 @@ namespace iRacingReplayDirector
             this.logMessagesButton = new System.Windows.Forms.Button();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabCapture = new System.Windows.Forms.TabPage();
+            this.cb_CloseiRacingAfterRecording = new System.Windows.Forms.CheckBox();
+            this.cb_ShutdownAfterEncode = new System.Windows.Forms.CheckBox();
+            this.cb_FastVideoRecording = new System.Windows.Forms.CheckBox();
+            this.cb_EncodeVideoAfterCapture = new System.Windows.Forms.CheckBox();
             this.verifyVideoCaptureButton = new System.Windows.Forms.Button();
             this.configureTrackCamerasLabel = new System.Windows.Forms.Label();
+            this.cb_ShortTestOnly = new System.Windows.Forms.CheckBox();
             this.WaitingForIRacingLabel = new System.Windows.Forms.Label();
             this.ProcessErrorMessageLabel = new System.Windows.Forms.Label();
             this.CapturingRaceLabel = new System.Windows.Forms.Label();
@@ -82,11 +87,7 @@ namespace iRacingReplayDirector
             this.configurePluginsButton = new System.Windows.Forms.Button();
             this.newVersionMessage = new System.Windows.Forms.Label();
             this.cb_UseNewSettingsDlg = new System.Windows.Forms.CheckBox();
-            this.cb_CloseiRacingAfterRecording = new System.Windows.Forms.CheckBox();
-            this.cb_ShutdownAfterEncode = new System.Windows.Forms.CheckBox();
-            this.cb_FastVideoRecording = new System.Windows.Forms.CheckBox();
-            this.cb_EncodeVideoAfterCapture = new System.Windows.Forms.CheckBox();
-            this.cb_ShortTestOnly = new System.Windows.Forms.CheckBox();
+            this.label_SupportedSession = new System.Windows.Forms.Label();
             this.tabControl1.SuspendLayout();
             this.tabCapture.SuspendLayout();
             this.tabTranscoding.SuspendLayout();
@@ -136,6 +137,7 @@ namespace iRacingReplayDirector
             // 
             // tabCapture
             // 
+            this.tabCapture.Controls.Add(this.label_SupportedSession);
             this.tabCapture.Controls.Add(this.cb_CloseiRacingAfterRecording);
             this.tabCapture.Controls.Add(this.cb_ShutdownAfterEncode);
             this.tabCapture.Controls.Add(this.cb_FastVideoRecording);
@@ -160,6 +162,58 @@ namespace iRacingReplayDirector
             this.tabCapture.Text = "Race Capture";
             this.tabCapture.UseVisualStyleBackColor = true;
             // 
+            // cb_CloseiRacingAfterRecording
+            // 
+            this.cb_CloseiRacingAfterRecording.AutoSize = true;
+            this.cb_CloseiRacingAfterRecording.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bCloseiRacingAfterRecording;
+            this.cb_CloseiRacingAfterRecording.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::iRacingReplayDirector.Properties.Settings.Default, "bCloseiRacingAfterRecording", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.cb_CloseiRacingAfterRecording.Location = new System.Drawing.Point(516, 29);
+            this.cb_CloseiRacingAfterRecording.Name = "cb_CloseiRacingAfterRecording";
+            this.cb_CloseiRacingAfterRecording.Size = new System.Drawing.Size(220, 23);
+            this.cb_CloseiRacingAfterRecording.TabIndex = 8;
+            this.cb_CloseiRacingAfterRecording.Text = "Close iRacing after Recording";
+            this.cb_CloseiRacingAfterRecording.UseVisualStyleBackColor = true;
+            this.cb_CloseiRacingAfterRecording.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
+            // 
+            // cb_ShutdownAfterEncode
+            // 
+            this.cb_ShutdownAfterEncode.AutoSize = true;
+            this.cb_ShutdownAfterEncode.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bShutdownPCAfterEncoding;
+            this.cb_ShutdownAfterEncode.Location = new System.Drawing.Point(516, 58);
+            this.cb_ShutdownAfterEncode.Name = "cb_ShutdownAfterEncode";
+            this.cb_ShutdownAfterEncode.Size = new System.Drawing.Size(210, 23);
+            this.cb_ShutdownAfterEncode.TabIndex = 8;
+            this.cb_ShutdownAfterEncode.Text = "Shutdown PC after Encoding";
+            this.cb_ShutdownAfterEncode.UseVisualStyleBackColor = true;
+            this.cb_ShutdownAfterEncode.CheckedChanged += new System.EventHandler(this.cb_ShutdownPCAfterEncoding_Changed);
+            // 
+            // cb_FastVideoRecording
+            // 
+            this.cb_FastVideoRecording.AutoSize = true;
+            this.cb_FastVideoRecording.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bFastVideoRecording;
+            this.cb_FastVideoRecording.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cb_FastVideoRecording.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::iRacingReplayDirector.Properties.Settings.Default, "bFastVideoRecording", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.cb_FastVideoRecording.Location = new System.Drawing.Point(300, 58);
+            this.cb_FastVideoRecording.Name = "cb_FastVideoRecording";
+            this.cb_FastVideoRecording.Size = new System.Drawing.Size(217, 23);
+            this.cb_FastVideoRecording.TabIndex = 8;
+            this.cb_FastVideoRecording.Text = "Fast-Video-Recording (alpha)";
+            this.cb_FastVideoRecording.UseVisualStyleBackColor = true;
+            this.cb_FastVideoRecording.CheckedChanged += new System.EventHandler(this.cb_FastVideoRecording_CheckedChanged);
+            // 
+            // cb_EncodeVideoAfterCapture
+            // 
+            this.cb_EncodeVideoAfterCapture.AutoSize = true;
+            this.cb_EncodeVideoAfterCapture.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bEncodeVideoAfterCapture;
+            this.cb_EncodeVideoAfterCapture.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::iRacingReplayDirector.Properties.Settings.Default, "bEncodeVideoAfterCapture", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.cb_EncodeVideoAfterCapture.Location = new System.Drawing.Point(300, 29);
+            this.cb_EncodeVideoAfterCapture.Name = "cb_EncodeVideoAfterCapture";
+            this.cb_EncodeVideoAfterCapture.Size = new System.Drawing.Size(207, 23);
+            this.cb_EncodeVideoAfterCapture.TabIndex = 8;
+            this.cb_EncodeVideoAfterCapture.Text = "Encode Video After Capture";
+            this.cb_EncodeVideoAfterCapture.UseVisualStyleBackColor = true;
+            this.cb_EncodeVideoAfterCapture.CheckedChanged += new System.EventHandler(this.EncodeVideoAfterCapture_CheckedChanged);
+            // 
             // verifyVideoCaptureButton
             // 
             this.verifyVideoCaptureButton.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -174,15 +228,27 @@ namespace iRacingReplayDirector
             // 
             // configureTrackCamerasLabel
             // 
-            this.configureTrackCamerasLabel.Font = new System.Drawing.Font("Calibri", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.configureTrackCamerasLabel.Font = new System.Drawing.Font("Calibri", 12F);
             this.configureTrackCamerasLabel.ForeColor = System.Drawing.Color.DarkRed;
-            this.configureTrackCamerasLabel.Location = new System.Drawing.Point(7, 115);
+            this.configureTrackCamerasLabel.Location = new System.Drawing.Point(6, 115);
             this.configureTrackCamerasLabel.Name = "configureTrackCamerasLabel";
-            this.configureTrackCamerasLabel.Size = new System.Drawing.Size(279, 30);
+            this.configureTrackCamerasLabel.Size = new System.Drawing.Size(547, 41);
             this.configureTrackCamerasLabel.TabIndex = 9;
             this.configureTrackCamerasLabel.Text = "You need to configure the Track Cameras before you can begin to capture this race" +
     ".";
             this.configureTrackCamerasLabel.Visible = false;
+            // 
+            // cb_ShortTestOnly
+            // 
+            this.cb_ShortTestOnly.AutoSize = true;
+            this.cb_ShortTestOnly.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bShortTestOnly;
+            this.cb_ShortTestOnly.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::iRacingReplayDirector.Properties.Settings.Default, "bShortTestOnly", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.cb_ShortTestOnly.Location = new System.Drawing.Point(174, 29);
+            this.cb_ShortTestOnly.Name = "cb_ShortTestOnly";
+            this.cb_ShortTestOnly.Size = new System.Drawing.Size(126, 23);
+            this.cb_ShortTestOnly.TabIndex = 7;
+            this.cb_ShortTestOnly.Text = "Short Test Only";
+            this.cb_ShortTestOnly.UseVisualStyleBackColor = true;
             // 
             // WaitingForIRacingLabel
             // 
@@ -472,69 +538,15 @@ namespace iRacingReplayDirector
             this.cb_UseNewSettingsDlg.UseVisualStyleBackColor = true;
             this.cb_UseNewSettingsDlg.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged_1);
             // 
-            // cb_CloseiRacingAfterRecording
+            // label_SupportedSession
             // 
-            this.cb_CloseiRacingAfterRecording.AutoSize = true;
-            this.cb_CloseiRacingAfterRecording.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bCloseiRacingAfterRecording;
-            this.cb_CloseiRacingAfterRecording.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::iRacingReplayDirector.Properties.Settings.Default, "bCloseiRacingAfterRecording", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.cb_CloseiRacingAfterRecording.Location = new System.Drawing.Point(516, 29);
-            this.cb_CloseiRacingAfterRecording.Name = "cb_CloseiRacingAfterRecording";
-            this.cb_CloseiRacingAfterRecording.Size = new System.Drawing.Size(220, 23);
-            this.cb_CloseiRacingAfterRecording.TabIndex = 8;
-            this.cb_CloseiRacingAfterRecording.Text = "Close iRacing after Recording";
-            this.cb_CloseiRacingAfterRecording.UseVisualStyleBackColor = true;
-            this.cb_CloseiRacingAfterRecording.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
-            // 
-            // cb_ShutdownAfterEncode
-            // 
-            this.cb_ShutdownAfterEncode.AutoSize = true;
-            this.cb_ShutdownAfterEncode.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bShutdownPCAfterEncoding;
-            this.cb_ShutdownAfterEncode.Location = new System.Drawing.Point(516, 58);
-            this.cb_ShutdownAfterEncode.Name = "cb_ShutdownAfterEncode";
-            this.cb_ShutdownAfterEncode.Size = new System.Drawing.Size(210, 23);
-            this.cb_ShutdownAfterEncode.TabIndex = 8;
-            this.cb_ShutdownAfterEncode.Text = "Shutdown PC after Encoding";
-            this.cb_ShutdownAfterEncode.UseVisualStyleBackColor = true;
-            this.cb_ShutdownAfterEncode.CheckedChanged += new System.EventHandler(this.cb_ShutdownPCAfterEncoding_Changed);
-            // 
-            // cb_FastVideoRecording
-            // 
-            this.cb_FastVideoRecording.AutoSize = true;
-            this.cb_FastVideoRecording.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bFastVideoRecording;
-            this.cb_FastVideoRecording.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cb_FastVideoRecording.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::iRacingReplayDirector.Properties.Settings.Default, "bFastVideoRecording", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.cb_FastVideoRecording.Location = new System.Drawing.Point(300, 58);
-            this.cb_FastVideoRecording.Name = "cb_FastVideoRecording";
-            this.cb_FastVideoRecording.Size = new System.Drawing.Size(217, 23);
-            this.cb_FastVideoRecording.TabIndex = 8;
-            this.cb_FastVideoRecording.Text = "Fast-Video-Recording (alpha)";
-            this.cb_FastVideoRecording.UseVisualStyleBackColor = true;
-            this.cb_FastVideoRecording.CheckedChanged += new System.EventHandler(this.cb_FastVideoRecording_CheckedChanged);
-            // 
-            // cb_EncodeVideoAfterCapture
-            // 
-            this.cb_EncodeVideoAfterCapture.AutoSize = true;
-            this.cb_EncodeVideoAfterCapture.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bEncodeVideoAfterCapture;
-            this.cb_EncodeVideoAfterCapture.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::iRacingReplayDirector.Properties.Settings.Default, "bEncodeVideoAfterCapture", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.cb_EncodeVideoAfterCapture.Location = new System.Drawing.Point(300, 29);
-            this.cb_EncodeVideoAfterCapture.Name = "cb_EncodeVideoAfterCapture";
-            this.cb_EncodeVideoAfterCapture.Size = new System.Drawing.Size(207, 23);
-            this.cb_EncodeVideoAfterCapture.TabIndex = 8;
-            this.cb_EncodeVideoAfterCapture.Text = "Encode Video After Capture";
-            this.cb_EncodeVideoAfterCapture.UseVisualStyleBackColor = true;
-            this.cb_EncodeVideoAfterCapture.CheckedChanged += new System.EventHandler(this.EncodeVideoAfterCapture_CheckedChanged);
-            // 
-            // cb_ShortTestOnly
-            // 
-            this.cb_ShortTestOnly.AutoSize = true;
-            this.cb_ShortTestOnly.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bShortTestOnly;
-            this.cb_ShortTestOnly.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::iRacingReplayDirector.Properties.Settings.Default, "bShortTestOnly", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.cb_ShortTestOnly.Location = new System.Drawing.Point(174, 29);
-            this.cb_ShortTestOnly.Name = "cb_ShortTestOnly";
-            this.cb_ShortTestOnly.Size = new System.Drawing.Size(126, 23);
-            this.cb_ShortTestOnly.TabIndex = 7;
-            this.cb_ShortTestOnly.Text = "Short Test Only";
-            this.cb_ShortTestOnly.UseVisualStyleBackColor = true;
+            this.label_SupportedSession.ForeColor = System.Drawing.Color.DarkRed;
+            this.label_SupportedSession.Location = new System.Drawing.Point(3, 115);
+            this.label_SupportedSession.Name = "label_SupportedSession";
+            this.label_SupportedSession.Size = new System.Drawing.Size(547, 41);
+            this.label_SupportedSession.TabIndex = 19;
+            this.label_SupportedSession.Text = "Not supported replay session - just Road or Oval supported";
+            this.label_SupportedSession.Visible = false;
             // 
             // Main
             // 
@@ -613,5 +625,6 @@ namespace iRacingReplayDirector
         private System.Windows.Forms.CheckBox cb_FastVideoRecording;
         private System.Windows.Forms.CheckBox cb_CloseiRacingAfterRecording;
         private System.Windows.Forms.CheckBox cb_UseNewSettingsDlg;
+        private System.Windows.Forms.Label label_SupportedSession;
     }
 }

--- a/Main.Designer.cs
+++ b/Main.Designer.cs
@@ -53,6 +53,7 @@ namespace iRacingReplayDirector
             this.logMessagesButton = new System.Windows.Forms.Button();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabCapture = new System.Windows.Forms.TabPage();
+            this.label_SupportedSession = new System.Windows.Forms.Label();
             this.cb_CloseiRacingAfterRecording = new System.Windows.Forms.CheckBox();
             this.cb_ShutdownAfterEncode = new System.Windows.Forms.CheckBox();
             this.cb_FastVideoRecording = new System.Windows.Forms.CheckBox();
@@ -87,7 +88,6 @@ namespace iRacingReplayDirector
             this.configurePluginsButton = new System.Windows.Forms.Button();
             this.newVersionMessage = new System.Windows.Forms.Label();
             this.cb_UseNewSettingsDlg = new System.Windows.Forms.CheckBox();
-            this.label_SupportedSession = new System.Windows.Forms.Label();
             this.tabControl1.SuspendLayout();
             this.tabCapture.SuspendLayout();
             this.tabTranscoding.SuspendLayout();
@@ -161,6 +161,17 @@ namespace iRacingReplayDirector
             this.tabCapture.TabIndex = 0;
             this.tabCapture.Text = "Race Capture";
             this.tabCapture.UseVisualStyleBackColor = true;
+            // 
+            // label_SupportedSession
+            // 
+            this.label_SupportedSession.ForeColor = System.Drawing.Color.DarkRed;
+            this.label_SupportedSession.Location = new System.Drawing.Point(3, 115);
+            this.label_SupportedSession.Name = "label_SupportedSession";
+            this.label_SupportedSession.Size = new System.Drawing.Size(597, 41);
+            this.label_SupportedSession.TabIndex = 19;
+            this.label_SupportedSession.Text = "WARNING: ReplayDirector just tested with replays from Road and Oval Race sessions" +
+    "";
+            this.label_SupportedSession.Visible = false;
             // 
             // cb_CloseiRacingAfterRecording
             // 
@@ -537,16 +548,6 @@ namespace iRacingReplayDirector
             this.cb_UseNewSettingsDlg.Text = "Use New Settings Dialog (alpha)";
             this.cb_UseNewSettingsDlg.UseVisualStyleBackColor = true;
             this.cb_UseNewSettingsDlg.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged_1);
-            // 
-            // label_SupportedSession
-            // 
-            this.label_SupportedSession.ForeColor = System.Drawing.Color.DarkRed;
-            this.label_SupportedSession.Location = new System.Drawing.Point(3, 115);
-            this.label_SupportedSession.Name = "label_SupportedSession";
-            this.label_SupportedSession.Size = new System.Drawing.Size(547, 41);
-            this.label_SupportedSession.TabIndex = 19;
-            this.label_SupportedSession.Text = "Not supported replay session - just Road or Oval supported";
-            this.label_SupportedSession.Visible = false;
             // 
             // Main
             // 

--- a/Main.cs
+++ b/Main.cs
@@ -220,12 +220,29 @@ namespace iRacingReplayDirector
             iRacingProcess = new IRacingReplay()
                 .WhenIRacingStarts(() => 
                 {
-                    BeginProcessButton.Enabled = true;
+                    TestForSupportedSessionType();
                     workingFolderTextBox_TextChanged(null, null); 
-                    ProcessErrorMessageLabel.Visible = false; 
+                    ProcessErrorMessageLabel.Visible = false;
                     WaitingForIRacingLabel.Visible = false;
+
+                    
+                    
                 })
                 .InTheBackground(errorMessage => { });
+
+            
+        }
+
+        private void TestForSupportedSessionType()
+        {
+            //add here code to review whether replay does contain a supported session type
+
+            //and only enable the "Begin Capture" Button if that is the case
+            if (iRacing.IsConnected /*&& ??? */)
+            {
+                BeginProcessButton.Enabled = true;
+            }
+            BeginProcessButton.Enabled = true;
         }
 
         private void Main_FormClosing(object sender, FormClosingEventArgs e)

--- a/Main.cs
+++ b/Main.cs
@@ -236,7 +236,15 @@ namespace iRacingReplayDirector
         private bool ReplaySessionTypeSupported()
         {
             //add here code to review whether replay does contain a supported session type
-            return (curSession != null && (curSession.WeekendInfo.Category == "Road" || curSession.WeekendInfo.Category == "Oval"));  
+            if (curSession != null && (curSession.WeekendInfo.Category == "Road" || curSession.WeekendInfo.Category == "Oval"))
+            {   
+                label_SupportedSession.Visible = false;     //ensure that message with regard to wrong session type isn't shown
+            } else {
+                TraceInfo.WriteLineIf(!label_SupportedSession.Visible, "Not supported replay - just Oval or Road replays supported");
+                label_SupportedSession.Visible = true;      //otherwise make message box visible
+
+            }
+            return !label_SupportedSession.Visible;          //and return the inverse result
         }
 
         private void Main_FormClosing(object sender, FormClosingEventArgs e)
@@ -320,12 +328,16 @@ namespace iRacingReplayDirector
 
         void iracingEvents_Disconnected()
         {
-            isConnected = false;
+            TraceInfo.WriteLineIf(isConnected, "Disconnected from iRacing application");
+            isConnected = false;                        //disconnected from iRacing
+            curSession = null;                          //therefore Session data no longer valid
+            label_SupportedSession.Visible = false;     //and replay no hint about replay Session necessary
             StateUpdated();
         }
 
         void iracingEvents_Connected()
         {
+            TraceInfo.WriteLineIf(!isConnected, "Connected to iRacing application");
             isConnected = true;
             StateUpdated();
         }

--- a/Main.cs
+++ b/Main.cs
@@ -59,7 +59,7 @@ namespace iRacingReplayDirector
         System.Windows.Forms.Timer lookForAudioBitRates;
         LogMessages logMessagges;
         const string DefaultLogFileName = "general.log";
-        SessionData lastSession;
+        SessionData curSession;
         bool isConnected;
 
         States State
@@ -79,11 +79,11 @@ namespace iRacingReplayDirector
         {
             var trackCamerasDefined =
                 Settings.Default.trackCameras != null &&
-                lastSession != null &&
-                Settings.Default.trackCameras.Any(tc => tc.TrackName == lastSession.WeekendInfo.TrackDisplayName) &&
-                Settings.Default.trackCameras.RaceStart[lastSession.WeekendInfo.TrackDisplayName] != null &&
-                Settings.Default.trackCameras.Incident[lastSession.WeekendInfo.TrackDisplayName] != null &&
-                Settings.Default.trackCameras.LastLap[lastSession.WeekendInfo.TrackDisplayName] != null;
+                curSession != null &&
+                Settings.Default.trackCameras.Any(tc => tc.TrackName == curSession.WeekendInfo.TrackDisplayName) &&
+                Settings.Default.trackCameras.RaceStart[curSession.WeekendInfo.TrackDisplayName] != null &&
+                Settings.Default.trackCameras.Incident[curSession.WeekendInfo.TrackDisplayName] != null &&
+                Settings.Default.trackCameras.LastLap[curSession.WeekendInfo.TrackDisplayName] != null;
 
             switch (_states)
             {
@@ -236,7 +236,7 @@ namespace iRacingReplayDirector
         private bool ReplaySessionTypeSupported()
         {
             //add here code to review whether replay does contain a supported session type
-            return (lastSession != null && (lastSession.WeekendInfo.Category == "Road" || lastSession.WeekendInfo.Category == "Oval"));  
+            return (curSession != null && (curSession.WeekendInfo.Category == "Road" || curSession.WeekendInfo.Category == "Oval"));  
         }
 
         private void Main_FormClosing(object sender, FormClosingEventArgs e)
@@ -332,7 +332,7 @@ namespace iRacingReplayDirector
 
         void iracingEvents_NewSessionData(DataSample data)
         {
-            lastSession = data.SessionData;
+            curSession = data.SessionData;
             StateUpdated();
         }
 

--- a/Main.cs
+++ b/Main.cs
@@ -245,7 +245,7 @@ namespace iRacingReplayDirector
 
             }
             //return !label_SupportedSession.Visible;       //and return the inverse result
-            returen true;                                   //always return true to allow people testing of all Session types. Some which do not work for sure will be excluded in the future    
+            return true;                                   //always return true to allow people testing of all Session types. Some which do not work for sure will be excluded in the future    
         }
 
         private void Main_FormClosing(object sender, FormClosingEventArgs e)

--- a/Main.cs
+++ b/Main.cs
@@ -88,7 +88,7 @@ namespace iRacingReplayDirector
             switch (_states)
             {
                 case States.Idle:
-                    BeginProcessButton.Enabled = Directory.Exists(workingFolderTextBox.Text) && isConnected && trackCamerasDefined;
+                    BeginProcessButton.Enabled = Directory.Exists(workingFolderTextBox.Text) && isConnected && trackCamerasDefined && (lastSession != null && lastSession.WeekendInfo.Category == "Road");
                     configureTrackCamerasLabel.Visible = isConnected && !trackCamerasDefined;
                     transcodeVideoButton.Enabled = IsReadyForTranscoding();
                     transcodeCancelButton.Visible = false;
@@ -220,7 +220,7 @@ namespace iRacingReplayDirector
             iRacingProcess = new IRacingReplay()
                 .WhenIRacingStarts(() => 
                 {
-                    TestForSupportedSessionType();
+                    BeginProcessButton.Enabled = false;                 //Keep "Start Capture" Button disabled until supported session is verified using weekendinfo
                     workingFolderTextBox_TextChanged(null, null); 
                     ProcessErrorMessageLabel.Visible = false;
                     WaitingForIRacingLabel.Visible = false;
@@ -240,6 +240,8 @@ namespace iRacingReplayDirector
             //and only enable the "Begin Capture" Button if that is the case
             if (iRacing.IsConnected /*&& ??? */)
             {
+                var weekendInfo = lastSession.WeekendInfo;
+                //var data = iRacing.NewData();
                 BeginProcessButton.Enabled = true;
             }
             BeginProcessButton.Enabled = true;

--- a/Main.cs
+++ b/Main.cs
@@ -240,11 +240,12 @@ namespace iRacingReplayDirector
             {   
                 label_SupportedSession.Visible = false;     //ensure that message with regard to wrong session type isn't shown
             } else {
-                TraceInfo.WriteLineIf(!label_SupportedSession.Visible, "Not supported replay - just Oval or Road replays supported");
+                TraceInfo.WriteLineIf(!label_SupportedSession.Visible, "WARNING: ReplayDirector just tested with replays from Road and Oval Race sessions. You are able to use it with other replays as well - in case of issues report on GitHub ");
                 label_SupportedSession.Visible = true;      //otherwise make message box visible
 
             }
-            return !label_SupportedSession.Visible;          //and return the inverse result
+            //return !label_SupportedSession.Visible;       //and return the inverse result
+            returen true;                                   //always return true to allow people testing of all Session types. Some which do not work for sure will be excluded in the future    
         }
 
         private void Main_FormClosing(object sender, FormClosingEventArgs e)

--- a/Main.cs
+++ b/Main.cs
@@ -88,7 +88,7 @@ namespace iRacingReplayDirector
             switch (_states)
             {
                 case States.Idle:
-                    BeginProcessButton.Enabled = Directory.Exists(workingFolderTextBox.Text) && isConnected && trackCamerasDefined && (lastSession != null && (lastSession.WeekendInfo.Category == "Road" || lastSession.WeekendInfo.Category == "Oval"));
+                    BeginProcessButton.Enabled = Directory.Exists(workingFolderTextBox.Text) && isConnected && trackCamerasDefined && ReplaySessionTypeSupported();
                     configureTrackCamerasLabel.Visible = isConnected && !trackCamerasDefined;
                     transcodeVideoButton.Enabled = IsReadyForTranscoding();
                     transcodeCancelButton.Visible = false;
@@ -233,18 +233,10 @@ namespace iRacingReplayDirector
             
         }
 
-        private void TestForSupportedSessionType()
+        private bool ReplaySessionTypeSupported()
         {
             //add here code to review whether replay does contain a supported session type
-
-            //and only enable the "Begin Capture" Button if that is the case
-            if (iRacing.IsConnected /*&& ??? */)
-            {
-                var weekendInfo = lastSession.WeekendInfo;
-                //var data = iRacing.NewData();
-                BeginProcessButton.Enabled = true;
-            }
-            BeginProcessButton.Enabled = true;
+            return (lastSession != null && (lastSession.WeekendInfo.Category == "Road" || lastSession.WeekendInfo.Category == "Oval"));  
         }
 
         private void Main_FormClosing(object sender, FormClosingEventArgs e)

--- a/Main.cs
+++ b/Main.cs
@@ -88,7 +88,7 @@ namespace iRacingReplayDirector
             switch (_states)
             {
                 case States.Idle:
-                    BeginProcessButton.Enabled = Directory.Exists(workingFolderTextBox.Text) && isConnected && trackCamerasDefined && (lastSession != null && lastSession.WeekendInfo.Category == "Road");
+                    BeginProcessButton.Enabled = Directory.Exists(workingFolderTextBox.Text) && isConnected && trackCamerasDefined && (lastSession != null && (lastSession.WeekendInfo.Category == "Road" || lastSession.WeekendInfo.Category == "Oval"));
                     configureTrackCamerasLabel.Visible = isConnected && !trackCamerasDefined;
                     transcodeVideoButton.Enabled = IsReadyForTranscoding();
                     transcodeCancelButton.Visible = false;


### PR DESCRIPTION
closes #65 

Warning added when people do load race replays others than from oval or road races. At the moment people still can use the iRacingReplayDirector - sessions types definitely not working will be excluded in the future.

Further enhancement for today not supported session types will have low priority. 