### PR TITLE
Fix Highlights Last Lap Trimming

### DIFF
--- a/Main.Designer.cs
+++ b/Main.Designer.cs
@@ -74,6 +74,7 @@ namespace iRacingReplayDirector
             this.transcodeProgressBar = new System.Windows.Forms.ProgressBar();
             this.button2 = new System.Windows.Forms.Button();
             this.cb_HighLightVideoOnly = new System.Windows.Forms.CheckBox();
+            this.cb_OverlayOnly = new System.Windows.Forms.CheckBox();
             this.VideoDetailLabel = new System.Windows.Forms.Label();
             this.videoBitRate = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
@@ -116,7 +117,7 @@ namespace iRacingReplayDirector
             // 
             // logMessagesButton
             // 
-            this.logMessagesButton.Location = new System.Drawing.Point(563, 13);
+            this.logMessagesButton.Location = new System.Drawing.Point(743, 13);
             this.logMessagesButton.Name = "logMessagesButton";
             this.logMessagesButton.Size = new System.Drawing.Size(112, 27);
             this.logMessagesButton.TabIndex = 3;
@@ -132,7 +133,7 @@ namespace iRacingReplayDirector
             this.tabControl1.Location = new System.Drawing.Point(13, 79);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(754, 339);
+            this.tabControl1.Size = new System.Drawing.Size(934, 440);
             this.tabControl1.TabIndex = 5;
             // 
             // tabCapture
@@ -157,7 +158,7 @@ namespace iRacingReplayDirector
             this.tabCapture.Location = new System.Drawing.Point(4, 31);
             this.tabCapture.Name = "tabCapture";
             this.tabCapture.Padding = new System.Windows.Forms.Padding(3);
-            this.tabCapture.Size = new System.Drawing.Size(746, 304);
+            this.tabCapture.Size = new System.Drawing.Size(746, 370);
             this.tabCapture.TabIndex = 0;
             this.tabCapture.Text = "Race Capture";
             this.tabCapture.UseVisualStyleBackColor = true;
@@ -165,9 +166,9 @@ namespace iRacingReplayDirector
             // label_SupportedSession
             // 
             this.label_SupportedSession.ForeColor = System.Drawing.Color.DarkRed;
-            this.label_SupportedSession.Location = new System.Drawing.Point(3, 115);
+            this.label_SupportedSession.Location = new System.Drawing.Point(3, 165);
             this.label_SupportedSession.Name = "label_SupportedSession";
-            this.label_SupportedSession.Size = new System.Drawing.Size(597, 41);
+            this.label_SupportedSession.Size = new System.Drawing.Size(900, 60);
             this.label_SupportedSession.TabIndex = 19;
             this.label_SupportedSession.Text = "WARNING: ReplayDirector just tested with replays from Road and Oval Race sessions" +
     "";
@@ -178,7 +179,7 @@ namespace iRacingReplayDirector
             this.cb_CloseiRacingAfterRecording.AutoSize = true;
             this.cb_CloseiRacingAfterRecording.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bCloseiRacingAfterRecording;
             this.cb_CloseiRacingAfterRecording.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::iRacingReplayDirector.Properties.Settings.Default, "bCloseiRacingAfterRecording", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.cb_CloseiRacingAfterRecording.Location = new System.Drawing.Point(516, 29);
+            this.cb_CloseiRacingAfterRecording.Location = new System.Drawing.Point(185, 104);
             this.cb_CloseiRacingAfterRecording.Name = "cb_CloseiRacingAfterRecording";
             this.cb_CloseiRacingAfterRecording.Size = new System.Drawing.Size(220, 23);
             this.cb_CloseiRacingAfterRecording.TabIndex = 8;
@@ -190,7 +191,7 @@ namespace iRacingReplayDirector
             // 
             this.cb_ShutdownAfterEncode.AutoSize = true;
             this.cb_ShutdownAfterEncode.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bShutdownPCAfterEncoding;
-            this.cb_ShutdownAfterEncode.Location = new System.Drawing.Point(516, 58);
+            this.cb_ShutdownAfterEncode.Location = new System.Drawing.Point(185, 132);
             this.cb_ShutdownAfterEncode.Name = "cb_ShutdownAfterEncode";
             this.cb_ShutdownAfterEncode.Size = new System.Drawing.Size(210, 23);
             this.cb_ShutdownAfterEncode.TabIndex = 8;
@@ -204,7 +205,7 @@ namespace iRacingReplayDirector
             this.cb_FastVideoRecording.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bFastVideoRecording;
             this.cb_FastVideoRecording.CheckState = System.Windows.Forms.CheckState.Checked;
             this.cb_FastVideoRecording.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::iRacingReplayDirector.Properties.Settings.Default, "bFastVideoRecording", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.cb_FastVideoRecording.Location = new System.Drawing.Point(300, 58);
+            this.cb_FastVideoRecording.Location = new System.Drawing.Point(185, 76);
             this.cb_FastVideoRecording.Name = "cb_FastVideoRecording";
             this.cb_FastVideoRecording.Size = new System.Drawing.Size(217, 23);
             this.cb_FastVideoRecording.TabIndex = 8;
@@ -217,7 +218,7 @@ namespace iRacingReplayDirector
             this.cb_EncodeVideoAfterCapture.AutoSize = true;
             this.cb_EncodeVideoAfterCapture.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bEncodeVideoAfterCapture;
             this.cb_EncodeVideoAfterCapture.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::iRacingReplayDirector.Properties.Settings.Default, "bEncodeVideoAfterCapture", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.cb_EncodeVideoAfterCapture.Location = new System.Drawing.Point(300, 29);
+            this.cb_EncodeVideoAfterCapture.Location = new System.Drawing.Point(185, 48);
             this.cb_EncodeVideoAfterCapture.Name = "cb_EncodeVideoAfterCapture";
             this.cb_EncodeVideoAfterCapture.Size = new System.Drawing.Size(207, 23);
             this.cb_EncodeVideoAfterCapture.TabIndex = 8;
@@ -228,7 +229,7 @@ namespace iRacingReplayDirector
             // verifyVideoCaptureButton
             // 
             this.verifyVideoCaptureButton.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.verifyVideoCaptureButton.Location = new System.Drawing.Point(586, 180);
+            this.verifyVideoCaptureButton.Location = new System.Drawing.Point(766, 237);
             this.verifyVideoCaptureButton.Margin = new System.Windows.Forms.Padding(4);
             this.verifyVideoCaptureButton.Name = "verifyVideoCaptureButton";
             this.verifyVideoCaptureButton.Size = new System.Drawing.Size(153, 30);
@@ -241,7 +242,7 @@ namespace iRacingReplayDirector
             // 
             this.configureTrackCamerasLabel.Font = new System.Drawing.Font("Calibri", 12F);
             this.configureTrackCamerasLabel.ForeColor = System.Drawing.Color.DarkRed;
-            this.configureTrackCamerasLabel.Location = new System.Drawing.Point(6, 115);
+            this.configureTrackCamerasLabel.Location = new System.Drawing.Point(6, 165);
             this.configureTrackCamerasLabel.Name = "configureTrackCamerasLabel";
             this.configureTrackCamerasLabel.Size = new System.Drawing.Size(547, 41);
             this.configureTrackCamerasLabel.TabIndex = 9;
@@ -254,9 +255,9 @@ namespace iRacingReplayDirector
             this.cb_ShortTestOnly.AutoSize = true;
             this.cb_ShortTestOnly.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bShortTestOnly;
             this.cb_ShortTestOnly.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::iRacingReplayDirector.Properties.Settings.Default, "bShortTestOnly", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.cb_ShortTestOnly.Location = new System.Drawing.Point(174, 29);
+            this.cb_ShortTestOnly.Location = new System.Drawing.Point(185, 20);
             this.cb_ShortTestOnly.Name = "cb_ShortTestOnly";
-            this.cb_ShortTestOnly.Size = new System.Drawing.Size(126, 23);
+            this.cb_ShortTestOnly.Size = new System.Drawing.Size(250, 23);
             this.cb_ShortTestOnly.TabIndex = 7;
             this.cb_ShortTestOnly.Text = "Short Test Only";
             this.cb_ShortTestOnly.UseVisualStyleBackColor = true;
@@ -264,7 +265,7 @@ namespace iRacingReplayDirector
             // WaitingForIRacingLabel
             // 
             this.WaitingForIRacingLabel.ForeColor = System.Drawing.Color.DarkRed;
-            this.WaitingForIRacingLabel.Location = new System.Drawing.Point(6, 115);
+            this.WaitingForIRacingLabel.Location = new System.Drawing.Point(6, 165);
             this.WaitingForIRacingLabel.Name = "WaitingForIRacingLabel";
             this.WaitingForIRacingLabel.Size = new System.Drawing.Size(547, 41);
             this.WaitingForIRacingLabel.TabIndex = 11;
@@ -273,7 +274,7 @@ namespace iRacingReplayDirector
             // ProcessErrorMessageLabel
             // 
             this.ProcessErrorMessageLabel.ForeColor = System.Drawing.Color.DarkRed;
-            this.ProcessErrorMessageLabel.Location = new System.Drawing.Point(6, 115);
+            this.ProcessErrorMessageLabel.Location = new System.Drawing.Point(6, 165);
             this.ProcessErrorMessageLabel.Name = "ProcessErrorMessageLabel";
             this.ProcessErrorMessageLabel.Size = new System.Drawing.Size(547, 50);
             this.ProcessErrorMessageLabel.TabIndex = 10;
@@ -283,7 +284,7 @@ namespace iRacingReplayDirector
             // CapturingRaceLabel
             // 
             this.CapturingRaceLabel.ForeColor = System.Drawing.Color.DarkRed;
-            this.CapturingRaceLabel.Location = new System.Drawing.Point(6, 115);
+            this.CapturingRaceLabel.Location = new System.Drawing.Point(6, 165);
             this.CapturingRaceLabel.Name = "CapturingRaceLabel";
             this.CapturingRaceLabel.Size = new System.Drawing.Size(406, 50);
             this.CapturingRaceLabel.TabIndex = 12;
@@ -293,7 +294,7 @@ namespace iRacingReplayDirector
             // AnalysingRaceLabel
             // 
             this.AnalysingRaceLabel.ForeColor = System.Drawing.Color.DarkRed;
-            this.AnalysingRaceLabel.Location = new System.Drawing.Point(6, 115);
+            this.AnalysingRaceLabel.Location = new System.Drawing.Point(6, 165);
             this.AnalysingRaceLabel.Name = "AnalysingRaceLabel";
             this.AnalysingRaceLabel.Size = new System.Drawing.Size(406, 50);
             this.AnalysingRaceLabel.TabIndex = 13;
@@ -302,9 +303,9 @@ namespace iRacingReplayDirector
             // 
             // label2
             // 
-            this.label2.Location = new System.Drawing.Point(6, 226);
+            this.label2.Location = new System.Drawing.Point(6, 280);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(594, 55);
+            this.label2.Size = new System.Drawing.Size(714, 55);
             this.label2.TabIndex = 18;
             this.label2.Text = "Load iRacing with your race replay. You may need to press the space bar to remove" +
     " the iRacing overlay.";
@@ -324,7 +325,7 @@ namespace iRacingReplayDirector
             // 
             // workingFolderButton
             // 
-            this.workingFolderButton.Location = new System.Drawing.Point(516, 180);
+            this.workingFolderButton.Location = new System.Drawing.Point(696, 237);
             this.workingFolderButton.Name = "workingFolderButton";
             this.workingFolderButton.Size = new System.Drawing.Size(64, 30);
             this.workingFolderButton.TabIndex = 16;
@@ -335,7 +336,7 @@ namespace iRacingReplayDirector
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(6, 185);
+            this.label5.Location = new System.Drawing.Point(6, 240);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(149, 19);
             this.label5.TabIndex = 14;
@@ -343,9 +344,9 @@ namespace iRacingReplayDirector
             // 
             // workingFolderTextBox
             // 
-            this.workingFolderTextBox.Location = new System.Drawing.Point(156, 182);
+            this.workingFolderTextBox.Location = new System.Drawing.Point(156, 237);
             this.workingFolderTextBox.Name = "workingFolderTextBox";
-            this.workingFolderTextBox.Size = new System.Drawing.Size(355, 27);
+            this.workingFolderTextBox.Size = new System.Drawing.Size(535, 27);
             this.workingFolderTextBox.TabIndex = 15;
             this.workingFolderTextBox.TextChanged += new System.EventHandler(this.workingFolderTextBox_TextChanged);
             // 
@@ -354,6 +355,7 @@ namespace iRacingReplayDirector
             this.tabTranscoding.Controls.Add(this.transcodeProgressBar);
             this.tabTranscoding.Controls.Add(this.button2);
             this.tabTranscoding.Controls.Add(this.cb_HighLightVideoOnly);
+            this.tabTranscoding.Controls.Add(this.cb_OverlayOnly);
             this.tabTranscoding.Controls.Add(this.VideoDetailLabel);
             this.tabTranscoding.Controls.Add(this.videoBitRate);
             this.tabTranscoding.Controls.Add(this.label1);
@@ -376,13 +378,13 @@ namespace iRacingReplayDirector
             this.transcodeProgressBar.Margin = new System.Windows.Forms.Padding(4);
             this.transcodeProgressBar.Maximum = 10000;
             this.transcodeProgressBar.Name = "transcodeProgressBar";
-            this.transcodeProgressBar.Size = new System.Drawing.Size(700, 34);
+            this.transcodeProgressBar.Size = new System.Drawing.Size(820, 34);
             this.transcodeProgressBar.TabIndex = 31;
             // 
             // button2
             // 
             this.button2.Font = new System.Drawing.Font("Calibri", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button2.Location = new System.Drawing.Point(585, 166);
+            this.button2.Location = new System.Drawing.Point(705, 166);
             this.button2.Margin = new System.Windows.Forms.Padding(4);
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(153, 30);
@@ -404,6 +406,19 @@ namespace iRacingReplayDirector
             this.cb_HighLightVideoOnly.TabIndex = 25;
             this.cb_HighLightVideoOnly.Text = "Highlight Video Only";
             this.cb_HighLightVideoOnly.UseVisualStyleBackColor = true;
+            // 
+            // cb_OverlayOnly
+            // 
+            this.cb_OverlayOnly.AutoSize = true;
+            this.cb_OverlayOnly.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.cb_OverlayOnly.Checked = global::iRacingReplayDirector.Properties.Settings.Default.bOverlayOnly;
+            this.cb_OverlayOnly.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::iRacingReplayDirector.Properties.Settings.Default, "bOverlayOnly", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.cb_OverlayOnly.Location = new System.Drawing.Point(429, 83);
+            this.cb_OverlayOnly.Name = "cb_OverlayOnly";
+            this.cb_OverlayOnly.Size = new System.Drawing.Size(162, 23);
+            this.cb_OverlayOnly.TabIndex = 26;
+            this.cb_OverlayOnly.Text = "Overlay Only";
+            this.cb_OverlayOnly.UseVisualStyleBackColor = true;
             // 
             // VideoDetailLabel
             // 
@@ -433,7 +448,7 @@ namespace iRacingReplayDirector
             // 
             // sourceVideoButton
             // 
-            this.sourceVideoButton.Location = new System.Drawing.Point(674, 134);
+            this.sourceVideoButton.Location = new System.Drawing.Point(794, 134);
             this.sourceVideoButton.Name = "sourceVideoButton";
             this.sourceVideoButton.Size = new System.Drawing.Size(64, 27);
             this.sourceVideoButton.TabIndex = 28;
@@ -454,7 +469,7 @@ namespace iRacingReplayDirector
             // 
             this.sourceVideoTextBox.Location = new System.Drawing.Point(116, 135);
             this.sourceVideoTextBox.Name = "sourceVideoTextBox";
-            this.sourceVideoTextBox.Size = new System.Drawing.Size(552, 27);
+            this.sourceVideoTextBox.Size = new System.Drawing.Size(672, 27);
             this.sourceVideoTextBox.TabIndex = 27;
             this.sourceVideoTextBox.TextChanged += new System.EventHandler(this.sourceVideoTextBox_TextChanged);
             // 
@@ -489,13 +504,13 @@ namespace iRacingReplayDirector
             this.pictureBox3.Location = new System.Drawing.Point(17, 115);
             this.pictureBox3.Margin = new System.Windows.Forms.Padding(4);
             this.pictureBox3.Name = "pictureBox3";
-            this.pictureBox3.Size = new System.Drawing.Size(745, 5);
+            this.pictureBox3.Size = new System.Drawing.Size(925, 5);
             this.pictureBox3.TabIndex = 36;
             this.pictureBox3.TabStop = false;
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(681, 13);
+            this.button1.Location = new System.Drawing.Point(861, 13);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(86, 27);
             this.button1.TabIndex = 4;
@@ -505,7 +520,7 @@ namespace iRacingReplayDirector
             // 
             // changeVersionButton
             // 
-            this.changeVersionButton.Location = new System.Drawing.Point(631, 46);
+            this.changeVersionButton.Location = new System.Drawing.Point(811, 46);
             this.changeVersionButton.Name = "changeVersionButton";
             this.changeVersionButton.Size = new System.Drawing.Size(136, 27);
             this.changeVersionButton.TabIndex = 37;
@@ -553,7 +568,7 @@ namespace iRacingReplayDirector
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 19F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(779, 424);
+            this.ClientSize = new System.Drawing.Size(960, 530);
             this.Controls.Add(this.cb_UseNewSettingsDlg);
             this.Controls.Add(this.newVersionMessage);
             this.Controls.Add(this.configurePluginsButton);
@@ -613,6 +628,7 @@ namespace iRacingReplayDirector
         private System.Windows.Forms.Button transcodeVideoButton;
         private System.Windows.Forms.PictureBox pictureBox3;
         private System.Windows.Forms.CheckBox cb_HighLightVideoOnly;
+        private System.Windows.Forms.CheckBox cb_OverlayOnly;
         private System.Windows.Forms.Label configureTrackCamerasLabel;
         private System.Windows.Forms.Button verifyVideoCaptureButton;
         private System.Windows.Forms.Button button1;

--- a/Main.cs
+++ b/Main.cs
@@ -195,6 +195,7 @@ namespace iRacingReplayDirector
             cb_FastVideoRecording.Checked = Properties.Settings.Default.bFastVideoRecording;
             cb_ShortTestOnly.Checked = Properties.Settings.Default.bShortTestOnly;
             cb_HighLightVideoOnly.Checked = Properties.Settings.Default.bHighLightVideoOnly;
+            cb_OverlayOnly.Checked = Properties.Settings.Default.bOverlayOnly;
             cb_UseNewSettingsDlg.Checked = Properties.Settings.Default.bUseNewSettingsDialog;
 
 
@@ -258,6 +259,7 @@ namespace iRacingReplayDirector
             Properties.Settings.Default.bFastVideoRecording = cb_FastVideoRecording.Checked;
             Properties.Settings.Default.bShortTestOnly = cb_ShortTestOnly.Checked;
             Properties.Settings.Default.bHighLightVideoOnly = cb_HighLightVideoOnly.Checked;
+            Properties.Settings.Default.bOverlayOnly = cb_OverlayOnly.Checked;
             //enable change of standard setting to use NewSettingsDialog only after intensive testings that all values can be reliably set using the advanced settings dialog
             //Properties.Settings.Default.bUseNewSettingsDialog = cb_UseNewSettingsDlg.Checked;
             Properties.Settings.Default.Save();
@@ -383,7 +385,7 @@ namespace iRacingReplayDirector
             iRacingProcess = new IRacingReplay()
                 .WithEncodingOf(videoBitRate: videoBitRateNumber * 1000000)
                 .WithOverlayFile(overlayFile: sourceVideoTextBox.Text)
-                .OverlayRaceDataOntoVideo(OnTranscoderProgress, OnTranscoderCompleted, cb_HighLightVideoOnly.Checked, cb_ShutdownAfterEncode.Checked)
+                .OverlayRaceDataOntoVideo(OnTranscoderProgress, OnTranscoderCompleted, cb_HighLightVideoOnly.Checked, cb_ShutdownAfterEncode.Checked, cb_OverlayOnly.Checked)
                 .InTheBackground(errorMessage =>
                 {
                     OnTranscoderCompleted();

--- a/Phases/IRacingReplay.OverlayRaceDataOntoVideo.cs
+++ b/Phases/IRacingReplay.OverlayRaceDataOntoVideo.cs
@@ -32,6 +32,7 @@ namespace iRacingReplayDirector.Phases
         int videoBitRate;
         string destinationFile;
         string destinationHighlightsFile;
+        string destinationOverlayOnlyFile;
         string gameDataFile;
 
         public void _WithEncodingOf(int videoBitRate)
@@ -43,31 +44,41 @@ namespace iRacingReplayDirector.Phases
         {
             destinationFile = Path.ChangeExtension(overlayFileName, "mp4");
             destinationHighlightsFile = Path.ChangeExtension(overlayFileName, ".highlights.mp4");
+            destinationOverlayOnlyFile = Path.ChangeExtension(overlayFileName, ".overlayonly.mp4");
 
             gameDataFile = overlayFileName;
         }
 
-        public void _OverlayRaceDataOntoVideo(Action<long, long> progress, Action completed, bool highlightOnly, bool bShutdownAfterCompleted, CancellationToken token)
+        public void _OverlayRaceDataOntoVideo(Action<long, long> progress, Action completed, bool highlightOnly, bool bShutdownAfterCompleted, CancellationToken token, bool overlayOnly = false)
         {
-            bool TranscodeFull = !highlightOnly;
+            bool TranscodeFull = !highlightOnly && !overlayOnly;
 
             var transcodeHigh = new Task(() => TranscodeAndOverlayMarshaled.Apply("HighLights", gameDataFile, videoBitRate, destinationHighlightsFile, true, highlightOnly ? progress : null, token));
+            var transcodeOverlayOnly = new Task(() => TranscodeAndOverlayMarshaled.Apply("OverlayOnly", gameDataFile, videoBitRate, destinationOverlayOnlyFile, false, overlayOnly ? progress : null, token, overlayOnly: true));
             var transcodeFull = new Task(() => TranscodeAndOverlayMarshaled.Apply("Full", gameDataFile, videoBitRate, destinationFile, false, progress, token));
 
             using (MFSystem.Start())
             {
                 var waits = new List<Task>();
 
-                transcodeHigh.Start();
-                waits.Add(transcodeHigh);
-
-                //Seem to have some kind of bug in MediaFoundation - where if two threads attempt to open source Readers to the same file, we get exception raised.
-                //To work around issue, delay the start of the second transcoder - so we dont have two threads opening at the same time.
-                if (TranscodeFull)
+                if (overlayOnly)
                 {
-                    Thread.Sleep(10000);
-                    transcodeFull.Start();
-                    waits.Add(transcodeFull);
+                    transcodeOverlayOnly.Start();
+                    waits.Add(transcodeOverlayOnly);
+                }
+                else
+                {
+                    transcodeHigh.Start();
+                    waits.Add(transcodeHigh);
+
+                    //Seem to have some kind of bug in MediaFoundation - where if two threads attempt to open source Readers to the same file, we get exception raised.
+                    //To work around issue, delay the start of the second transcoder - so we dont have two threads opening at the same time.
+                    if (TranscodeFull)
+                    {
+                        Thread.Sleep(10000);
+                        transcodeFull.Start();
+                        waits.Add(transcodeFull);
+                    }
                 }
 
                 Task.WaitAll(waits.ToArray());

--- a/Phases/IRacingReplay.OverlayRaceDataOntoVideo.cs
+++ b/Phases/IRacingReplay.OverlayRaceDataOntoVideo.cs
@@ -41,8 +41,8 @@ namespace iRacingReplayDirector.Phases
 
         public void _WithOverlayFile(string overlayFileName)
         {
-            destinationFile = Path.ChangeExtension(overlayFileName, "wmv");
-            destinationHighlightsFile = Path.ChangeExtension(overlayFileName, ".highlights.wmv");
+            destinationFile = Path.ChangeExtension(overlayFileName, "mp4");
+            destinationHighlightsFile = Path.ChangeExtension(overlayFileName, ".highlights.mp4");
 
             gameDataFile = overlayFileName;
         }

--- a/Phases/IRacingReplay.cs
+++ b/Phases/IRacingReplay.cs
@@ -121,7 +121,7 @@ namespace iRacingReplayDirector.Phases
             return this;
         }
 
-        public IRacingReplay OverlayRaceDataOntoVideo(Action<long, long> progress, Action completed, bool highlightsOnly, bool shutdownAfterCompleted)
+        public IRacingReplay OverlayRaceDataOntoVideo(Action<long, long> progress, Action completed, bool highlightsOnly, bool shutdownAfterCompleted, bool overlayOnly = false)
         {
             var context = SynchronizationContext.Current;
 
@@ -131,7 +131,8 @@ namespace iRacingReplayDirector.Phases
                     () => context.Post(completed),
                     highlightsOnly,
                     shutdownAfterCompleted,
-                    token
+                    token,
+                    overlayOnly
                 )
             );
 

--- a/Phases/TranscodeAndOverlay.cs
+++ b/Phases/TranscodeAndOverlay.cs
@@ -264,7 +264,7 @@ namespace iRacingReplayDirector.Phases
         {
             var cut = next;
 
-            var raceEdits = leaderBoard.OverlayData.RaceEvents.GetRaceEdits();
+            var raceEdits = leaderBoard.OverlayData.GetRaceEdits();
             if (raceEdits.Count() == 0)
                 throw new Exception("Unable to create highlight - try reducing time for highlight duration");
             var firstEdit = raceEdits.First();

--- a/Phases/TranscodeAndOverlay.cs
+++ b/Phases/TranscodeAndOverlay.cs
@@ -31,7 +31,7 @@ namespace iRacingReplayDirector.Phases
 {
     public class TranscodeAndOverlayMarshaled
     {
-        public static void Apply(string name, string gameDataFile, int videoBitRate, string destFile, bool highlights, Action<long, long> progressReporter, CancellationToken token)
+        public static void Apply(string name, string gameDataFile, int videoBitRate, string destFile, bool highlights, Action<long, long> progressReporter, CancellationToken token, bool overlayOnly = false)
         {
             var domain = AppDomain.CreateDomain(name, null, new AppDomainSetup());
             try
@@ -44,7 +44,7 @@ namespace iRacingReplayDirector.Phases
                     false,
                     BindingFlags.CreateInstance,
                     null,
-                    new object[] { gameDataFile, videoBitRate, destFile, highlights, (Action<long, long>)hostArgs.ProgressReporter, (Func<bool>)hostArgs.IsAborted, hostArgs.LogRepeater, Settings.Default.PluginName },
+                    new object[] { gameDataFile, videoBitRate, destFile, highlights, (Action<long, long>)hostArgs.ProgressReporter, (Func<bool>)hostArgs.IsAborted, hostArgs.LogRepeater, Settings.Default.PluginName, overlayOnly },
                     null,
                     null);
                 arg.Apply();
@@ -104,6 +104,7 @@ namespace iRacingReplayDirector.Phases
         private string destFile;
         private string gameDataFile;
         private bool highlights;
+        private bool overlayOnly;
         private Func<bool> _isAborted;
         private Action<long, long> _progressReporter;
         private int videoBitRate;
@@ -118,7 +119,7 @@ namespace iRacingReplayDirector.Phases
             this.logRepeater = new LogRepeater();
         }
 
-        public TranscodeAndOverlayArguments(string gameDataFile, int videoBitRate, string destFile, bool highlights, Action<long, long> progressReporter, Func<bool> isAborted, LogRepeater logRepeater, string pluginName)
+        public TranscodeAndOverlayArguments(string gameDataFile, int videoBitRate, string destFile, bool highlights, Action<long, long> progressReporter, Func<bool> isAborted, LogRepeater logRepeater, string pluginName, bool overlayOnly = false)
         {
             //Constructed in subdomain
             Program.MakePortable(Settings.Default);
@@ -127,6 +128,7 @@ namespace iRacingReplayDirector.Phases
             this.videoBitRate = videoBitRate;
             this.destFile = destFile;
             this.highlights = highlights;
+            this.overlayOnly = overlayOnly;
             this._progressReporter = progressReporter;
             this._isAborted = isAborted;
             this.pluginName = pluginName;
@@ -150,13 +152,13 @@ namespace iRacingReplayDirector.Phases
 
         public void Apply()
         {
-            TranscodeAndOverlay.Apply(gameDataFile, videoBitRate, destFile, highlights, ProgressReporter, IsAborted, pluginName);
+            TranscodeAndOverlay.Apply(gameDataFile, videoBitRate, destFile, highlights, ProgressReporter, IsAborted, pluginName, overlayOnly);
         }
     }
 
     public class TranscodeAndOverlay
     {
-        public static void Apply(string gameDataFile, int videoBitRate, string destFile, bool highlights, Action<long, long> progressReporter, Func<bool> isAborted, string pluginName)
+        public static void Apply(string gameDataFile, int videoBitRate, string destFile, bool highlights, Action<long, long> progressReporter, Func<bool> isAborted, string pluginName, bool overlayOnly = false)
         {
             try
             {
@@ -169,7 +171,7 @@ namespace iRacingReplayDirector.Phases
                     VideoBitRate = videoBitRate
                 };
 
-                new TranscodeAndOverlay(leaderBoard, progressReporter).Process(transcoder, highlights, progressReporter, isAborted);
+                new TranscodeAndOverlay(leaderBoard, progressReporter).Process(transcoder, highlights, progressReporter, isAborted, overlayOnly);
             }
             catch (Exception e)
             {
@@ -189,19 +191,20 @@ namespace iRacingReplayDirector.Phases
             this.progressReporter = progressReporter;
         }
 
-        void Process(Transcoder transcoder, bool highlights, Action<long, long> monitorProgress, Func<bool> isAborted)
+        void Process(Transcoder transcoder, bool highlights, Action<long, long> monitorProgress, Func<bool> isAborted, bool overlayOnly = false)
         {
             try
             {
-                TraceInfo.WriteLineIf(highlights, "Transcoding highlights to {0}", transcoder.DestinationFile);
-                TraceInfo.WriteLineIf(!highlights, "Transcoding full replay to {0}", transcoder.DestinationFile);
+                TraceInfo.WriteLineIf(overlayOnly, "Transcoding overlay-only to {0}", transcoder.DestinationFile);
+                TraceInfo.WriteLineIf(highlights && !overlayOnly, "Transcoding highlights to {0}", transcoder.DestinationFile);
+                TraceInfo.WriteLineIf(!highlights && !overlayOnly, "Transcoding full replay to {0}", transcoder.DestinationFile);
 
                 transcoder.ProcessVideo((readers, saveToSink) =>
                 {
                     var writeToSink = monitorProgress == null ? saveToSink : MonitorProgress(saveToSink);
 
                     var fadeSegments = AVOperations.FadeIn(AVOperations.FadeOut(writeToSink));
-                    var edits = highlights ? ApplyEdits(writeToSink) : writeToSink;
+                    var edits = overlayOnly ? ApplyOverlayOnlyEdits(writeToSink) : (highlights ? ApplyEdits(writeToSink) : writeToSink);
                     var mainBodyOverlays = AVOperations.Overlay(applyRaceDataOverlay, edits);
                     var introOverlay = AVOperations.Overlay(applyIntroOverlay, fadeSegments);
 
@@ -269,6 +272,32 @@ namespace iRacingReplayDirector.Phases
                 throw new Exception("Unable to create highlight - try reducing time for highlight duration");
             var firstEdit = raceEdits.First();
             var lastEdit = raceEdits.Last();
+
+            foreach (var editCut in raceEdits)
+            {
+                cut = AVOperations.Cut(editCut.StartTime.FromSecondsToNano(), editCut.EndTime.FromSecondsToNano(), AVOperations.FadeInOut(cut));
+                totalDuration -= editCut.EndTime.FromSecondsToNano() - editCut.StartTime.FromSecondsToNano();
+            }
+
+            return cut;
+        }
+
+        ProcessSample ApplyOverlayOnlyEdits(ProcessSample next)
+        {
+            var cut = next;
+
+            double totalTime;
+            var overlayEvents = RaceEventExtension.GetAllFirstAndLastLapEvents(
+                leaderBoard.OverlayData.RaceEvents,
+                leaderBoard.OverlayData.TimeForOutroOverlay,
+                out totalTime);
+
+            if (overlayEvents.Count == 0)
+                throw new Exception("Unable to create overlay-only cut - no first/last lap events found");
+
+            var raceEdits = overlayEvents.GetRaceEdits();
+            if (raceEdits.Count == 0)
+                return cut;
 
             foreach (var editCut in raceEdits)
             {

--- a/Phases/Transcoding/RaceHighlightEdits.cs
+++ b/Phases/Transcoding/RaceHighlightEdits.cs
@@ -31,6 +31,12 @@ namespace iRacingReplayDirector.Phases.Transcoding
             get { return (Settings.Default.HighlightVideoTargetDuration.TotalMinutes * Settings.AppliedTimingFactor).Minutes(); }
         }
 
+        /// <summary>
+        /// Minimum seconds an event must contribute to be considered for gap-filling.
+        /// Events shorter than this are skipped to avoid fragmenting the highlight video.
+        /// </summary>
+        const double MinimumEventContributionSeconds = 15;
+
         public static List<VideoEdit> GetRaceEdits(this IEnumerable<OverlayData.RaceEvent> raceEvents)
         {
             var edits = raceEvents._GetRaceEdits().ToList();
@@ -43,9 +49,32 @@ namespace iRacingReplayDirector.Phases.Transcoding
             return edits;
         }
 
+        public static List<VideoEdit> GetRaceEdits(this OverlayData overlayData)
+        {
+            var edits = overlayData.RaceEvents._GetRaceEdits(overlayData.TimeForOutroOverlay).ToList();
+
+            foreach (var e in edits)
+                TraceInfo.WriteLine("Editing from {0} to {1}. Duration {2}", e.StartTimeSpan, e.EndTimeSpan, e.Duration);
+
+            TraceInfo.WriteLine("Total Edits time {0}", edits.Sum(e => e.Duration).Seconds());
+
+            return edits;
+        }
+
         static IEnumerable<VideoEdit> _GetRaceEdits(this IEnumerable<OverlayData.RaceEvent> raceEvents)
         {
-            var totalRaceEvents = GetInterestingRaceEvents(raceEvents);
+            return _GetRaceEdits(raceEvents, null);
+        }
+
+        static IEnumerable<VideoEdit> _GetRaceEdits(this IEnumerable<OverlayData.RaceEvent> raceEvents, double? timeForOutroOverlay)
+        {
+            // Get untrimmed events first to know the original video end time
+            var untrimmedEvents = GetInterestingRaceEvents(raceEvents, null);
+            var originalEndTime = untrimmedEvents.Max(e => e.EndTime);
+
+            var totalRaceEvents = timeForOutroOverlay.HasValue
+                ? GetInterestingRaceEvents(raceEvents, timeForOutroOverlay)
+                : untrimmedEvents;
 
             var previousEvent = totalRaceEvents.First();
             foreach (var re in totalRaceEvents.Skip(1))
@@ -64,14 +93,28 @@ namespace iRacingReplayDirector.Phases.Transcoding
 
                 previousEvent = re;
             }
+
+            // If we trimmed the last lap, cut everything after the trimmed end to the original end
+            var lastEvent = totalRaceEvents.Last();
+            if (timeForOutroOverlay.HasValue && lastEvent.EndTime < originalEndTime)
+            {
+                TraceInfo.WriteLine("Highlight Edits: Cutting trailing content from {0} to {1}",
+                    lastEvent.EndTime.Seconds(), originalEndTime.Seconds());
+                yield return new VideoEdit { StartTime = lastEvent.EndTime, EndTime = originalEndTime };
+            }
         }
 
         public static IOrderedEnumerable<OverlayData.RaceEvent> GetInterestingRaceEvents(IEnumerable<OverlayData.RaceEvent> raceEvents, Boolean bFastRecording = false)
         {
+            return GetInterestingRaceEvents(raceEvents, null, bFastRecording);
+        }
+
+        public static IOrderedEnumerable<OverlayData.RaceEvent> GetInterestingRaceEvents(IEnumerable<OverlayData.RaceEvent> raceEvents, double? timeForOutroOverlay, Boolean bFastRecording = false)
+        {
             TraceInfo.WriteLine("Highlight Edits: Total Duration Target: {0}", HighlightVideoDuration);
 
             double totalTime, incidentsRatio, restartsRatio, battlesRatio, timeForRaceEvents;
-            var firstAndLastLapRaceEvents = GetAllFirstAndLastLapEvents(raceEvents, out totalTime);
+            var firstAndLastLapRaceEvents = GetAllFirstAndLastLapEvents(raceEvents, timeForOutroOverlay, out totalTime);
 
             var incidentRaceEvents = GetAllRaceEvents(raceEvents, InterestState.Incident, 1.8, 0, out incidentsRatio);
             var restartRaceEvents = GetAllRaceEvents(raceEvents, InterestState.Restart, 1.0, 0, out restartsRatio);
@@ -99,11 +142,38 @@ namespace iRacingReplayDirector.Phases.Transcoding
             var restartsEdited = ExtractEditedEvents(totalTime, restartPercentage, restartRaceEvents, InterestState.Restart);
             var battlessEdited = ExtractEditedEvents(totalTime, battlePercentage, battleRaceEvents, InterestState.Battle);
 
-            var editedEvents = firstAndLastLapRaceEvents.Concat(incidentsEdited).Concat(restartsEdited).Concat(battlessEdited).OrderBy(re => re.StartTime);
+            var editedEventsList = firstAndLastLapRaceEvents
+                .Concat(incidentsEdited)
+                .Concat(restartsEdited)
+                .Concat(battlessEdited)
+                .ToList();
 
-            TraceInfo.WriteLine("Highlight Edits: Expected duration of highlight video: {0}", editedEvents.Sum(re => re.Duration).Seconds());
+            // Calculate effective duration (accounting for overlapping events)
+            var effectiveDuration = CalculateMergedDuration(editedEventsList);
+            var targetDuration = HighlightVideoDuration.TotalSeconds;
+            var gap = targetDuration - effectiveDuration;
 
-            return editedEvents;
+            TraceInfo.WriteLine("Highlight Edits: Effective duration (merged): {0}, Gap to fill: {1}",
+                effectiveDuration.Seconds(), gap.Seconds());
+
+            // If there's a significant gap, fill it with additional events
+            if (gap > MinimumEventContributionSeconds)
+            {
+                var selectedSet = new HashSet<OverlayData.RaceEvent>(editedEventsList);
+                var remainingEvents = incidentRaceEvents
+                    .Concat(battleRaceEvents)
+                    .Concat(restartRaceEvents)
+                    .Where(e => !selectedSet.Contains(e))
+                    .OrderBy(e => e.StartTime)
+                    .ToList();
+
+                editedEventsList = FillGapWithAdditionalEvents(editedEventsList, remainingEvents, gap);
+            }
+
+            TraceInfo.WriteLine("Highlight Edits: Expected duration of highlight video: {0}", editedEventsList.Sum(re => re.Duration).Seconds());
+            TraceInfo.WriteLine("Highlight Edits: Final effective duration (merged): {0}", CalculateMergedDuration(editedEventsList).Seconds());
+
+            return editedEventsList.OrderBy(re => re.StartTime);
         }
 
         private static List<OverlayData.RaceEvent> NormaliseBattleEvents(List<OverlayData.RaceEvent> raceEvents, double maxDuration)
@@ -134,9 +204,42 @@ namespace iRacingReplayDirector.Phases.Transcoding
 
         static List<OverlayData.RaceEvent> GetAllFirstAndLastLapEvents(IEnumerable<OverlayData.RaceEvent> raceEvents, out double totalTime)
         {
+            return GetAllFirstAndLastLapEvents(raceEvents, null, out totalTime);
+        }
+
+        static List<OverlayData.RaceEvent> GetAllFirstAndLastLapEvents(IEnumerable<OverlayData.RaceEvent> raceEvents, double? timeForOutroOverlay, out double totalTime)
+        {
             var firstAndLastLapRaceEvents = raceEvents
                 .Where(re => re.Interest == InterestState.FirstLap || re.Interest == InterestState.LastLap)
                 .ToList();
+
+            // Trim LastLap events to end when the outro overlay ends (30 seconds after trigger)
+            if (timeForOutroOverlay.HasValue)
+            {
+                var outroEndTime = timeForOutroOverlay.Value + 30;  // 30 seconds matches TranscodeAndOverlay.cs
+
+                for (int i = 0; i < firstAndLastLapRaceEvents.Count; i++)
+                {
+                    var re = firstAndLastLapRaceEvents[i];
+                    if (re.Interest == InterestState.LastLap && re.EndTime > outroEndTime)
+                    {
+                        var trimmedEvent = new OverlayData.RaceEvent
+                        {
+                            Interest = re.Interest,
+                            StartTime = re.StartTime,
+                            EndTime = Math.Max(re.StartTime, outroEndTime),
+                            WithOvertake = re.WithOvertake,
+                            Position = re.Position,
+                            RaceLapNumber = re.RaceLapNumber
+                        };
+                        firstAndLastLapRaceEvents[i] = trimmedEvent;
+
+                        TraceInfo.WriteLine("Highlight Edits: Trimmed LastLap event from {0} to {1}",
+                            re.EndTime.Seconds(), trimmedEvent.EndTime.Seconds());
+                    }
+                }
+            }
+
             var firstAndLastLapDuration = firstAndLastLapRaceEvents.Sum(re => re.Duration);
             totalTime = HighlightVideoDuration.TotalSeconds - firstAndLastLapDuration;
 
@@ -255,6 +358,120 @@ namespace iRacingReplayDirector.Phases.Transcoding
             TraceInfo.WriteLine("Highlight Edits: {0}.  Duration: {1}, Factor: {2}, Ratio: {3}", interest.ToString(), duration.Seconds(), factor, ratio);
 
             return result;
+        }
+
+        static List<OverlayData.RaceEvent> FillGapWithAdditionalEvents(
+            List<OverlayData.RaceEvent> selectedEvents,
+            List<OverlayData.RaceEvent> remainingEvents,
+            double gap)
+        {
+            var result = new List<OverlayData.RaceEvent>(selectedEvents);
+            var coveredRanges = GetMergedRanges(result);
+
+            // Filter to events that contribute new content (not fully overlapped)
+            var contributingEvents = remainingEvents
+                .Where(e => CalculateContribution(e, coveredRanges) > MinimumEventContributionSeconds)
+                .ToList();
+
+            if (contributingEvents.Count == 0)
+                return result;
+
+            TraceInfo.WriteLine("Highlight Edits: Filling gap with {0} candidate events", contributingEvents.Count);
+
+            // Use the same SliceEvent distribution logic to pick additional events
+            var additionalEvents = ExtractEditedEvents(gap, 1.0, contributingEvents, InterestState.Battle);
+            result.AddRange(additionalEvents);
+
+            return result;
+        }
+
+        static double CalculateMergedDuration(IEnumerable<OverlayData.RaceEvent> events)
+        {
+            var ranges = GetMergedRanges(events);
+            return ranges.Sum(r => r.Item2 - r.Item1);
+        }
+
+        static List<Tuple<double, double>> GetMergedRanges(IEnumerable<OverlayData.RaceEvent> events)
+        {
+            var sortedRanges = events
+                .Select(e => Tuple.Create(e.StartTime, e.EndTime))
+                .OrderBy(r => r.Item1)
+                .ToList();
+
+            if (sortedRanges.Count == 0)
+                return new List<Tuple<double, double>>();
+
+            var result = new List<Tuple<double, double>>();
+            var currentStart = sortedRanges[0].Item1;
+            var currentEnd = sortedRanges[0].Item2;
+
+            foreach (var range in sortedRanges.Skip(1))
+            {
+                if (range.Item1 <= currentEnd)
+                {
+                    // Overlapping or adjacent, extend current range
+                    currentEnd = Math.Max(currentEnd, range.Item2);
+                }
+                else
+                {
+                    // Gap found, save current range and start new one
+                    result.Add(Tuple.Create(currentStart, currentEnd));
+                    currentStart = range.Item1;
+                    currentEnd = range.Item2;
+                }
+            }
+            result.Add(Tuple.Create(currentStart, currentEnd));
+
+            return result;
+        }
+
+        static double CalculateContribution(OverlayData.RaceEvent re, List<Tuple<double, double>> coveredRanges)
+        {
+            // Calculate how much of this event's time range is NOT already covered
+            var uncoveredParts = new List<Tuple<double, double>> { Tuple.Create(re.StartTime, re.EndTime) };
+
+            foreach (var range in coveredRanges)
+            {
+                var newUncovered = new List<Tuple<double, double>>();
+
+                foreach (var part in uncoveredParts)
+                {
+                    var partStart = part.Item1;
+                    var partEnd = part.Item2;
+                    var rangeStart = range.Item1;
+                    var rangeEnd = range.Item2;
+
+                    if (rangeEnd <= partStart || rangeStart >= partEnd)
+                    {
+                        // No overlap with this part
+                        newUncovered.Add(part);
+                    }
+                    else if (rangeStart <= partStart && rangeEnd >= partEnd)
+                    {
+                        // Part is fully covered, remove it (don't add to newUncovered)
+                    }
+                    else if (rangeStart > partStart && rangeEnd < partEnd)
+                    {
+                        // Range is inside part, split into two uncovered segments
+                        newUncovered.Add(Tuple.Create(partStart, rangeStart));
+                        newUncovered.Add(Tuple.Create(rangeEnd, partEnd));
+                    }
+                    else if (rangeStart <= partStart)
+                    {
+                        // Range overlaps start of part
+                        newUncovered.Add(Tuple.Create(rangeEnd, partEnd));
+                    }
+                    else
+                    {
+                        // Range overlaps end of part
+                        newUncovered.Add(Tuple.Create(partStart, rangeStart));
+                    }
+                }
+
+                uncoveredParts = newUncovered;
+            }
+
+            return uncoveredParts.Sum(p => p.Item2 - p.Item1);
         }
 
         struct _RaceEvent

--- a/Phases/Transcoding/RaceHighlightEdits.cs
+++ b/Phases/Transcoding/RaceHighlightEdits.cs
@@ -202,12 +202,12 @@ namespace iRacingReplayDirector.Phases.Transcoding
             return result;
         }
 
-        static List<OverlayData.RaceEvent> GetAllFirstAndLastLapEvents(IEnumerable<OverlayData.RaceEvent> raceEvents, out double totalTime)
+        public static List<OverlayData.RaceEvent> GetAllFirstAndLastLapEvents(IEnumerable<OverlayData.RaceEvent> raceEvents, out double totalTime)
         {
             return GetAllFirstAndLastLapEvents(raceEvents, null, out totalTime);
         }
 
-        static List<OverlayData.RaceEvent> GetAllFirstAndLastLapEvents(IEnumerable<OverlayData.RaceEvent> raceEvents, double? timeForOutroOverlay, out double totalTime)
+        public static List<OverlayData.RaceEvent> GetAllFirstAndLastLapEvents(IEnumerable<OverlayData.RaceEvent> raceEvents, double? timeForOutroOverlay, out double totalTime)
         {
             var firstAndLastLapRaceEvents = raceEvents
                 .Where(re => re.Interest == InterestState.FirstLap || re.Interest == InterestState.LastLap)

--- a/Phases/Transcoding/Transcoder.cs
+++ b/Phases/Transcoding/Transcoder.cs
@@ -1,4 +1,5 @@
-﻿// This file is part of iRacingReplayDirector.
+﻿
+// This file is part of iRacingReplayDirector.
 //
 // Copyright 2014 Dean Netherton
 // https://github.com/vipoo/iRacingReplayDirector.net
@@ -77,7 +78,9 @@ namespace iRacingReplayDirector.Phases.Transcoding
             var attributes = new Attributes
             {
                 ReadWriterEnableHardwareTransforms = true,
-                SourceReaderEnableVideoProcessing = true
+                SourceReaderEnableVideoProcessing = true,
+                H264Profile = eAVEncH264VProfile.High,
+                TranscodeContainerType = MFTranscodeContainer.Mpeg4
             };
 
             var readers = VideoFiles.Select(f => f.CreateSourceReader(readWriteFactory, attributes)).ToArray();
@@ -113,7 +116,9 @@ namespace iRacingReplayDirector.Phases.Transcoding
             var attributes = new Attributes
             {
                 ReadWriterEnableHardwareTransforms = true,
-                SourceReaderEnableVideoProcessing = true
+                SourceReaderEnableVideoProcessing = true,
+                H264Profile = eAVEncH264VProfile.High,
+                TranscodeContainerType = MFTranscodeContainer.Mpeg4
             };
 
             var readers = VideoFiles.Select(f => f.CreateSourceReader(readWriteFactory, attributes)).ToArray();

--- a/Phases/Transcoding/Transcoder.cs
+++ b/Phases/Transcoding/Transcoder.cs
@@ -1,5 +1,4 @@
-﻿
-// This file is part of iRacingReplayDirector.
+﻿// This file is part of iRacingReplayDirector.
 //
 // Copyright 2014 Dean Netherton
 // https://github.com/vipoo/iRacingReplayDirector.net
@@ -68,8 +67,8 @@ namespace iRacingReplayDirector.Phases.Transcoding
         public string DestinationFile;
         public int VideoBitRate;
 
-        static Guid TARGET_AUDIO_FORMAT = MFMediaType.WMAudioV9;
-        static Guid TARGET_VIDEO_FORMAT = MFMediaType.WMV3;
+        static Guid TARGET_AUDIO_FORMAT = MFMediaType.AAC;
+        static Guid TARGET_VIDEO_FORMAT = MFMediaType.H264;
 
         internal string TestVideoConversion()
         {
@@ -83,7 +82,7 @@ namespace iRacingReplayDirector.Phases.Transcoding
 
             var readers = VideoFiles.Select(f => f.CreateSourceReader(readWriteFactory, attributes)).ToArray();
 
-            var testOuputFile = readers.First().FileName + ".tmp.test.wmv";
+            var testOuputFile = readers.First().FileName + ".tmp.test.mp4";
             try
             {
                 using (var sinkWriter = readWriteFactory.CreateSinkWriterFromURL(testOuputFile, attributes))

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -118,5 +118,17 @@ namespace iRacingReplayDirector.Properties {
                 this["bHighLightVideoOnly"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool bOverlayOnly {
+            get {
+                return ((bool)(this["bOverlayOnly"]));
+            }
+            set {
+                this["bOverlayOnly"] = value;
+            }
+        }
     }
 }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -26,5 +26,8 @@
     <Setting Name="bHighLightVideoOnly" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="bOverlayOnly" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Requirements
 * Your video capture software must save the video as an .mp4 or .avi file.
 * Replays should capture all competitors. Before the session, under the graphics options in iRacing, set the Max Cars box to a number greater than number of competitors.
 * Only tested with the PCM audio codec
-* Only supports MPEG/H.264 video codec for capture/conversion
+* Supports H.264 video codec with AAC audio in MP4 container for capture/conversion
 
 Known Issues
 ============
@@ -49,8 +49,8 @@ HOW TO USE
 10. Press Verify Video.
 11. Browse and select the video that was recorded in step 6.
 12. Click Verify Conversion.
-13. If all this worked correctly, you’ll find 1 or 2 .wmv files in the directory. These are your encoded videos. You’ll only have 1 if you checked the Highlight Video Only checkbox before encoding.
-14. If you’d like, you can now do a test run using the “Short Test Only” checkbox to verify everything is working. This is preferable to doing a 40 minute video and finding out something wasn’t setup correctly. Just follow the instructions below with the “Short Test Only” box checked.
+13. If all this worked correctly, you'll find 1 or 2 .mp4 files in the directory. These are your encoded videos. You'll only have 1 if you checked the Highlight Video Only checkbox before encoding.
+14. If you'd like, you can now do a test run using the "Short Test Only" checkbox to verify everything is working. This is preferable to doing a 40 minute video and finding out something wasn't setup correctly. Just follow the instructions below with the "Short Test Only" box checked.
 
 Creating a Video Thereafter
 ===========================
@@ -65,8 +65,8 @@ Creating a Video Thereafter
 9. Press the Begin Capture button when ready to capture.
 10. The process will run for at least the entire length of the original replay so be patient.
 11. Once the race capture is completed, you can then Encode your full race and highlight videos.
-12. When encoding, if the highlight Video Only isn’t checked, it creates 2 videos from your replays; the full replay and a highlight video with a length defined in the Config options. If the Highlight Video Only box is checked under Video Encoding, it will only create the highlight video.
-13. The completed videos have a .wmv extension
+12. When encoding, if the highlight Video Only isn't checked, it creates 2 videos from your replays; the full replay and a highlight video with a length defined in the Config options. If the Highlight Video Only box is checked under Video Encoding, it will only create the highlight video.
+13. The completed videos have a .mp4 extension
 
 History
 ==============

--- a/Video/Attributes.cs
+++ b/Video/Attributes.cs
@@ -87,7 +87,7 @@ namespace iRacingReplayDirector.Video
                 var channels = audioStream.NativeMediaType.AudioNumberOfChannels;
                 var sampleRate = audioStream.NativeMediaType.AudioSamplesPerSecond;
 
-                var types = MFSystem.TranscodeGetAudioOutputAvailableTypes(MediaFoundation.MFMediaType.WMAudioV9, MediaFoundation.Transform.MFT_EnumFlag.All);
+                var types = MFSystem.TranscodeGetAudioOutputAvailableTypes(MediaFoundation.MFMediaType.AAC, MediaFoundation.Transform.MFT_EnumFlag.All);
 
                 foreach (var bitRate in types
                     .Where(t => t.AudioSamplesPerSecond == sampleRate)
@@ -110,7 +110,7 @@ namespace iRacingReplayDirector.Video
                 var transcoder = new Transcoder
                 {
                     VideoFiles = new[] { new SourceReaderExtra(videoFileName, null) },
-                    DestinationFile = Path.ChangeExtension(videoFileName, "wmv"),
+                    DestinationFile = Path.ChangeExtension(videoFileName, "mp4"),
                     VideoBitRate = 5000000
                 };
 

--- a/build-and-run.bat
+++ b/build-and-run.bat
@@ -1,0 +1,4 @@
+@echo off
+call build.bat %1
+if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
+call run.bat %1

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,18 @@
+@echo off
+setlocal
+
+set MSBUILD="C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"
+set CONFIG=%1
+if "%CONFIG%"=="" set CONFIG=Debug
+
+echo Building iRacingReplayDirector [%CONFIG%]...
+%MSBUILD% iRacingReplayDirectorApps.sln -p:Configuration=%CONFIG% -p:Platform=x64 -restore -m -nologo -verbosity:minimal
+
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo BUILD FAILED.
+    exit /b %ERRORLEVEL%
+)
+
+echo.
+echo Build succeeded. Output: bin\%CONFIG%\iRacingReplayDirector.exe

--- a/plugins/JockeOverlays/MyPlugin.Extensions.cs
+++ b/plugins/JockeOverlays/MyPlugin.Extensions.cs
@@ -53,7 +53,7 @@ namespace JockeOverlays
                 .WithBrush(Styles.BlackBrush);
         }
 
-        public static GraphicRect DrawRedGradiantBox(this GraphicRect rr)
+        public static GraphicRect DrawBlueGradientBox(this GraphicRect rr)
         {
             return rr
                 .WithHeight(rr.Rectangle.Height + 3)

--- a/plugins/JockeOverlays/MyPlugin.FastestLaps.cs
+++ b/plugins/JockeOverlays/MyPlugin.FastestLaps.cs
@@ -17,7 +17,7 @@ namespace JockeOverlays
             const int top = 900;
 
             Graphics.InRectangle(left, top + 34, 400, 34)
-                .DrawRedGradiantBox();
+                .DrawBlueGradientBox();
 
             Graphics.InRectangle(left, top + 34, 250, 34)
                 .WithBrush(Styles.WhiteBrush)

--- a/plugins/JockeOverlays/MyPlugin.FlashCardHeading.cs
+++ b/plugins/JockeOverlays/MyPlugin.FlashCardHeading.cs
@@ -13,7 +13,7 @@ namespace JockeOverlays
                 .DrawGrayBackground();
 
             Graphics.InRectangle(FlashCardLeft - 10, 311 - 2, FlashCardWidth - 100, 48)
-                .DrawRedGradiantBox()
+                .DrawBlueGradientBox()
                 .MoveDown(7)
                 .MoveRight(20)
                 .WithFontSizeOf(23)

--- a/plugins/NoOverlay/MyPlugin.Extensions.cs
+++ b/plugins/NoOverlay/MyPlugin.Extensions.cs
@@ -53,7 +53,7 @@ namespace NoOverlay
                 .WithBrush(Styles.BlackBrush);
         }
 
-        public static GraphicRect DrawRedGradiantBox(this GraphicRect rr)
+        public static GraphicRect DrawBlueGradientBox(this GraphicRect rr)
         {
             return rr
                 .WithHeight(rr.Rectangle.Height + 3)

--- a/plugins/NoOverlay/MyPlugin.FastestLaps.cs
+++ b/plugins/NoOverlay/MyPlugin.FastestLaps.cs
@@ -17,7 +17,7 @@ namespace NoOverlay
             const int top = 900;
 
             Graphics.InRectangle(left, top + 34, 400, 34)
-                .DrawRedGradiantBox();
+                .DrawBlueGradientBox();
 
             Graphics.InRectangle(left, top + 34, 250, 34)
                 .WithBrush(Styles.WhiteBrush)

--- a/plugins/NoOverlay/MyPlugin.FlashCardHeading.cs
+++ b/plugins/NoOverlay/MyPlugin.FlashCardHeading.cs
@@ -13,7 +13,7 @@ namespace NoOverlay
                 .DrawGrayBackground();
 
             Graphics.InRectangle(FlashCardLeft - 10, 311 - 2, FlashCardWidth - 100, 48)
-                .DrawRedGradiantBox()
+                .DrawBlueGradientBox()
                 .MoveDown(7)
                 .MoveRight(20)
                 .WithFontSizeOf(23)

--- a/plugins/iRacingDirector.Plugin.StandardOverlays/MyPlugin.DriverCamera.cs
+++ b/plugins/iRacingDirector.Plugin.StandardOverlays/MyPlugin.DriverCamera.cs
@@ -15,7 +15,7 @@ namespace iRacingDirector.Plugin.StandardOverlays
             var offset = 5;
 
             Graphics.InRectangle(1920 / 2 - 440 / 2, 980, 70, 40)
-                .WithBrush(Styles.YellowBrush)
+                .WithBrush(Styles.BlueFlagYellowBrush)
                 .WithPen(Styles.BlackPen)
                 .DrawRectangleWithBorder()
                 .WithFontSizeOf(24)

--- a/plugins/iRacingDirector.Plugin.StandardOverlays/MyPlugin.Extensions.cs
+++ b/plugins/iRacingDirector.Plugin.StandardOverlays/MyPlugin.Extensions.cs
@@ -35,12 +35,12 @@ namespace iRacingDirector.Plugin.StandardOverlays
                 .WithBrush(Styles.BlackBrush);
         }
 
-        public static GraphicRect DrawRedGradiantBox(this GraphicRect rr)
+        public static GraphicRect DrawBlueGradientBox(this GraphicRect rr)
         {
             return rr
                 .WithHeight(rr.Rectangle.Height + 3)
                 .MoveUp(3)
-                .WithLinearGradientBrush(Styles.RedBannerDark, Styles.RedBannerLight, LinearGradientMode.Vertical)
+                .WithLinearGradientBrush(Styles.BlueFlagBlueDark, Styles.BlueFlagBlue, LinearGradientMode.Vertical)
                 .DrawRoundRectangle(5)
                 .WithBrush(Styles.WhiteBrush);
         }

--- a/plugins/iRacingDirector.Plugin.StandardOverlays/MyPlugin.FastestLaps.cs
+++ b/plugins/iRacingDirector.Plugin.StandardOverlays/MyPlugin.FastestLaps.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 
 namespace iRacingDirector.Plugin.StandardOverlays
 {
@@ -16,7 +17,7 @@ namespace iRacingDirector.Plugin.StandardOverlays
             const int top = 900;
 
             Graphics.InRectangle(left, top + 34, 400, 34)
-                .DrawRedGradiantBox();
+                .DrawBlueGradientBox();
 
             Graphics.InRectangle(left, top + 34, 250, 34)
                 .WithBrush(Styles.WhiteBrush)

--- a/plugins/iRacingDirector.Plugin.StandardOverlays/MyPlugin.FlashCardHeading.cs
+++ b/plugins/iRacingDirector.Plugin.StandardOverlays/MyPlugin.FlashCardHeading.cs
@@ -12,7 +12,7 @@ namespace iRacingDirector.Plugin.StandardOverlays
                 .DrawGrayBackground();
 
             Graphics.InRectangle(FlashCardLeft - 10, 311 - 2, FlashCardWidth - 100, 48)
-                .DrawRedGradiantBox()
+                .DrawBlueGradientBox()
                 .MoveDown(7)
                 .MoveRight(20)
                 .WithFontSizeOf(23)

--- a/plugins/iRacingDirector.Plugin.StandardOverlays/MyPlugin.Leaderboard.cs
+++ b/plugins/iRacingDirector.Plugin.StandardOverlays/MyPlugin.Leaderboard.cs
@@ -38,7 +38,7 @@ namespace iRacingDirector.Plugin.StandardOverlays
                 r = r.ToBelow();
 
                 headR.ToBelow()
-                    .DrawRedGradiantBox()
+                    .DrawBlueGradientBox()
                     .WithFont(Settings.FontName, 18, FontStyle.Bold)
                     .WithStringFormat(StringAlignment.Near)
                     .DrawText(LeaderBoard.LapCounter, topOffset: 8, leftOffset: 20);

--- a/plugins/iRacingDirector.Plugin.StandardOverlays/Styles.cs
+++ b/plugins/iRacingDirector.Plugin.StandardOverlays/Styles.cs
@@ -11,8 +11,11 @@ namespace iRacingDirector.Plugin.StandardOverlays
         public static readonly Color LightYellow = Color.FromArgb(AlphaLevel, Color.LightYellow);
         public static readonly Color Yellow = Color.FromArgb(AlphaLevel, 150, 150, 0);
 
-        public static readonly Color RedBannerDark = Color.DarkRed;
-        public static readonly Color RedBannerLight = Color.DarkRed.BrightenBy(1.4);
+        public static readonly Color BlueFlagBlue = Color.FromArgb(0x02, 0x5F, 0xE9);
+        public static readonly Color BlueFlagBlueDark = Color.FromArgb(0x00, 0x4B, 0xBD);
+
+        public static readonly Color BlueFlagYellow = Color.FromArgb(0xE8, 0xD1, 0x03);
+        public static readonly Color BlueFlagYellowDark = Color.FromArgb(0xB8, 0xA0, 0x00);
 
         public static readonly Pen BlackPen = new Pen(Black);
         public static readonly Pen ThickBlackPen = new Pen(Black, 2);
@@ -21,6 +24,7 @@ namespace iRacingDirector.Plugin.StandardOverlays
         public static readonly Brush RedBrush = new SolidBrush(Color.Red);
         public static readonly Brush WhiteBrush = new SolidBrush(Color.White);
         public static readonly Brush YellowBrush = new SolidBrush(Color.Yellow);
+        public static readonly Brush BlueFlagYellowBrush = new SolidBrush(Color.FromArgb(0xE8, 0xD1, 0x03));
         public static readonly Brush TransparentLightBlueBrush = new SolidBrush(Color.FromArgb(AlphaLevel, Color.LightBlue));
         public static readonly Brush TransparentLightGray = new SolidBrush(Color.FromArgb(180, Color.Gray));
         public static readonly Brush TransparentLighterGray = new SolidBrush(Color.FromArgb(40, Color.LightGray));

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,16 @@
+@echo off
+setlocal
+
+set CONFIG=%1
+if "%CONFIG%"=="" set CONFIG=Debug
+
+set EXE=bin\%CONFIG%\iRacingReplayDirector.exe
+
+if not exist "%EXE%" (
+    echo %EXE% not found. Building first...
+    call build.bat %CONFIG%
+    if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
+)
+
+echo Starting %EXE%...
+start "" "%EXE%"


### PR DESCRIPTION
## Problem Description

I noticed an issue pop up when generating highlights with this tool. Let's say you ask for a 12 minute highlight video. This tool takes the following steps:

1) Get **_ALL_** events from the first and last lap
2) Count up how much time this will take (let's say 3 minutes)
3) Subtract it from the overall budget, and allocate this remaining time (9 minutes) to events in between


It also does a separate thing with the results page display:

1) When a set driver crosses the finish line (default P3), display the results 
2) After 30 seconds (split evenly across 1-3 pages), take down the results


The problem is these two things are handled totally separately. I noticed for example if someone is way behind and takes an enormously long time to finish the last lap or simply stops on track, this will make it into the highlights, even if the results overlay has already completed. This is because the last lap doesn't end until everyone is off track and/or has seen checkered flag, so it's easy for something to go wrong here. 

Because of how the time budgeting works, this eats into actual race highlight time as well. So you can very well have a 12 minute video where 5-6 mins are the first/last lap. Here is an example of this kind of issue in action:

https://youtu.be/Tm4ElEaCEEs?si=s_2EG1JmbTK44_AP&t=615

You can see here that we're waiting enormously long for everyone to cross the finish line because one driver doesn't actually do it. 


## Solution

My approach here accomplishes two things.

1) It aligns the last highlight event with the completion of the results display. By default this means the highlights end 30 seconds after P3 crosses the finish line. This works well with 90% of use cases, and because it's tied to a setting, it can theoretically be configured in the future


2) After getting the final edit (with the end trimmed), it takes a look at how much budget was actually used. If it misses low due to the trimming, it takes a second pass and looks for more events to fill the time budget. It reuses existing SliceEvent logic for this. 


The end result is that highlights now end when the results are done displaying, and the actual length of the video is more accurate.